### PR TITLE
Ensure recursion runs for five rounds 

### DIFF
--- a/lib/mayor_game/city_calculator/city_helpers.ex
+++ b/lib/mayor_game/city_calculator/city_helpers.ex
@@ -478,7 +478,8 @@ defmodule MayorGame.CityHelpers do
     count = result_blob.updated_buildable_count
     result_blob = activation_round(result_blob, buildables, city, season, education_diff)
 
-    if result_blob.updated_buildable_count > count do
+    # enforce up to the full range of education level differences is considered, to prevent recursion from stopping early
+    if result_blob.updated_buildable_count > count && education_diff < 5 do
       # filter buildables for the next round of checks
       buildables_split_by_jobs =
         Enum.split_with(result_blob.result_buildables, fn y ->

--- a/lib/mayor_game/city_calculator/city_helpers.ex
+++ b/lib/mayor_game/city_calculator/city_helpers.ex
@@ -479,7 +479,7 @@ defmodule MayorGame.CityHelpers do
     result_blob = activation_round(result_blob, buildables, city, season, education_diff)
 
     # enforce up to the full range of education level differences is considered, to prevent recursion from stopping early
-    if result_blob.updated_buildable_count > count && education_diff < 5 do
+    if result_blob.updated_buildable_count > count || education_diff < 5 do
       # filter buildables for the next round of checks
       buildables_split_by_jobs =
         Enum.split_with(result_blob.result_buildables, fn y ->


### PR DESCRIPTION
Resolves an issue discovered by Beric01
![image](https://user-images.githubusercontent.com/22878527/218813757-6bee93eb-d501-41b2-a06a-bbe03677b377.png)

Each round of recursion allows one higher level to fill a lower level job (i.e. Round 1 = Lv 0 jobs are filled by Lv 0 workers only, Round 2 = Lv 0 jobs are filled by Lv 0 and Lv 1 workers, Round 3 = Lv 0 jobs are filled by Lv 0-2 workers etc.).

The issue is traced to the exit condition for the recursion method used to fill jobs. When there is no new buildings enabled by the recursion, the recursion is deemed to have completed and will exit. 

It is possible to exit early, if one round results in no change, though the next round will. In the screenshot below, the Lv 3 jobs are removed on purpose, which has the effect of preventing Lv 4s and Lv 5s from taking vacancies at Lv 0-2 as the recursion had stopped at Round 3 (Lv X+2), and Round 4 (Lv X+3) allowing Lv 4s to work on Lv 1s and Lv 5s on Lv 2 was not executed.
![image](https://user-images.githubusercontent.com/22878527/218817175-57df1ee8-b973-40fd-b5b2-5f073cfef106.png)


This PR forces the recursion to run for at least 5 times, ensuring all job level differences have been run at least once, before allowing a normal exit.
 
This would be the job situation after the change, Lv 5 can consistently fill Lv 1 jobs.
![image](https://user-images.githubusercontent.com/22878527/218818169-692f6d4e-9df2-40cc-a061-81eee959aa6b.png)
