### PR TITLE
Added Level 0 job requirement for Homeless Shelters

### DIFF
--- a/lib/mayor_game/city/buildable.ex
+++ b/lib/mayor_game/city/buildable.ex
@@ -222,7 +222,8 @@ defmodule MayorGame.City.Buildable do
         requires: %{
           area: 5,
           money: 100,
-          energy: 70
+          energy: 70,
+          workers: %{count: 5, level: 0},
         },
         produces: %{
           housing: 20


### PR DESCRIPTION
As described in the title: 5 Level 0 jobs to make the shelters operable.