### PR TITLE
Add distribution center building type

### DIFF
--- a/lib/mayor_game/city/buildable.ex
+++ b/lib/mayor_game/city/buildable.ex
@@ -88,7 +88,8 @@ defmodule MayorGame.City.Buildable do
         retail_shops: buildables_flat().retail_shops,
         factories: buildables_flat().factories,
         mines: buildables_flat().mines,
-        office_buildings: buildables_flat().office_buildings
+        office_buildings: buildables_flat().office_buildings,
+        distribution_centers: buildables_flat().distribution_centers
       },
       entertainment: %{
         theatres: buildables_flat().theatres,
@@ -149,7 +150,8 @@ defmodule MayorGame.City.Buildable do
         retail_shops: buildables_flat().retail_shops,
         factories: buildables_flat().factories,
         mines: buildables_flat().mines,
-        office_buildings: buildables_flat().office_buildings
+        office_buildings: buildables_flat().office_buildings,
+        distribution_centers: buildables_flat().distribution_centers
       ],
       entertainment: [
         theatres: buildables_flat().theatres,
@@ -799,6 +801,25 @@ defmodule MayorGame.City.Buildable do
           energy: 800,
           area: 2,
           workers: %{count: 20, level: 1}
+        }
+      },
+      # DISTRIBUTION CENTERS ————————————————————————————————
+      distribution_centers: %BuildableMetadata{
+        priority: 0,
+        title: :distribution_centers,
+        price: 100000,
+        purchasable: true,
+        purchasable_reason: "valid",
+        requires: %{
+          money: 25,
+          energy: 1500,
+          area: 100,
+          workers: %{count: 250, level: 0}
+        },
+        produces: %{
+          health: -3,
+          fun: -10,
+          pollution: 1
         }
       },
       # THEATRES ————————————————————————————————————

--- a/lib/mayor_game/city/town.ex
+++ b/lib/mayor_game/city/town.ex
@@ -103,6 +103,7 @@ defmodule MayorGame.City.Town do
             factories: integer,
             mines: integer,
             office_buildings: integer,
+            distribution_centers: integer,
             theatres: integer,
             arenas: integer,
             hospitals: integer,

--- a/priv/repo/migrations/20230215121430_add_distribution_centers.exs
+++ b/priv/repo/migrations/20230215121430_add_distribution_centers.exs
@@ -1,0 +1,9 @@
+defmodule MayorGame.Repo.Migrations.AddDistributionCenters do
+  use Ecto.Migration
+
+  def change do
+    alter table(:cities) do
+      add :distribution_centers, :integer, default: 0
+    end
+  end
+end


### PR DESCRIPTION
Distribution centers offer a way to create a large count of level 0 jobs. They take a large amount of area, aren't cheap, and have a health and fun cost to the city that builds them.

A city that wants to create a bulk load of low-level jobs can build these if they are willing to accept the tradeoffs of pollution, fun, and health.