### PR TITLE
Refactor, organization, fixes and optimization of city_helpers

### DIFF
--- a/lib/mayor_game/city/buildable.ex
+++ b/lib/mayor_game/city/buildable.ex
@@ -785,18 +785,9 @@ defmodule MayorGame.City.Buildable do
         },
         # fn _rng, _number_of_instances -> drop_amount
         produces: %{
-          education: fn rng, number_of_buildables ->
-            # low-luck calculation at 5% chance, so rng needs only be used once
-            aggregate = number_of_buildables * 0.05
-            whole = floor(aggregate)
-            chance = aggregate - whole
-
-            whole +
-              if rng < chance do
-                1
-              else
-                0
-              end
+          education: fn _rng, number_of_buildables ->
+            # simulate X dice rolls with chance 5%
+            round(Statistics.Distributions.Binomial.rand(number_of_buildables, 0.05))
           end
         }
       },
@@ -928,18 +919,9 @@ defmodule MayorGame.City.Buildable do
           pollution: 10,
           sulfur: 1,
           # fn _rng, _number_of_instances -> drop_amount
-          uranium: fn rng, number_of_buildables ->
-            # low-luck calculation at 0.001% chance, so rng needs only be used once
-            aggregate = number_of_buildables * 0.001
-            whole = floor(aggregate)
-            chance = aggregate - whole
-
-            whole +
-              if rng < chance do
-                1
-              else
-                0
-              end
+          uranium: fn _rng, number_of_buildables ->
+            # simulate X dice rolls with chance 0.1%
+            round(Statistics.Distributions.Binomial.rand(number_of_buildables, 0.001))
           end
           # gold: 1,
         }

--- a/lib/mayor_game/city/buildable.ex
+++ b/lib/mayor_game/city/buildable.ex
@@ -783,9 +783,21 @@ defmodule MayorGame.City.Buildable do
           energy: 200,
           workers: %{count: 4, level: 2}
         },
-        # todo: make random
+        # fn _rng, _number_of_instances -> drop_amount
         produces: %{
-          education: fn level, num -> %{level => num} end
+          education: fn rng, number_of_buildables ->
+            # low-luck calculation at 5% chance, so rng needs only be used once
+            aggregate = number_of_buildables * 0.05
+            whole = floor(aggregate)
+            chance = aggregate - whole
+
+            whole +
+              if rng < chance do
+                1
+              else
+                0
+              end
+          end
         }
       },
       # SCHOOLS ————————————————————————————————————
@@ -794,8 +806,6 @@ defmodule MayorGame.City.Buildable do
         level: 0,
         title: :schools,
         price: 2000,
-        education_level: 1,
-        capacity: 10,
         requires: %{
           money: 10,
           energy: 600,
@@ -803,7 +813,7 @@ defmodule MayorGame.City.Buildable do
           workers: %{count: 10, level: 0}
         },
         produces: %{
-          education: %{1 => 10}
+          education_lvl_1: 10
         }
       },
       # MIDDLE SCHOOLS ————————————————————————————————————
@@ -812,8 +822,6 @@ defmodule MayorGame.City.Buildable do
         level: 1,
         title: :middle_schools,
         price: 3000,
-        education_level: 2,
-        capacity: 10,
         requires: %{
           money: 40,
           energy: 800,
@@ -821,7 +829,7 @@ defmodule MayorGame.City.Buildable do
           workers: %{count: 10, level: 1}
         },
         produces: %{
-          education: %{2 => 10}
+          education_lvl_2: 10
         }
       },
       # HIGH SCHOOLS ————————————————————————————————————
@@ -830,8 +838,6 @@ defmodule MayorGame.City.Buildable do
         level: 2,
         title: :high_schools,
         price: 4000,
-        education_level: 3,
-        capacity: 10,
         requires: %{
           money: 70,
           energy: 800,
@@ -839,7 +845,7 @@ defmodule MayorGame.City.Buildable do
           workers: %{count: 10, level: 2}
         },
         produces: %{
-          education: %{3 => 10}
+          education_lvl_3: 10
         }
       },
       # UNIVERSITIES ————————————————————————————————————
@@ -848,8 +854,6 @@ defmodule MayorGame.City.Buildable do
         level: 3,
         title: :universities,
         price: 6500,
-        education_level: 4,
-        capacity: 10,
         requires: %{
           money: 150,
           energy: 1200,
@@ -857,7 +861,7 @@ defmodule MayorGame.City.Buildable do
           workers: %{count: 10, level: 3}
         },
         produces: %{
-          education: %{4 => 10}
+          education_lvl_4: 10
         }
       },
       # RESEARCH LABS ————————————————————————————————————
@@ -866,8 +870,6 @@ defmodule MayorGame.City.Buildable do
         level: 4,
         title: :research_labs,
         price: 9000,
-        education_level: 5,
-        capacity: 5,
         requires: %{
           money: 200,
           energy: 1200,
@@ -875,7 +877,7 @@ defmodule MayorGame.City.Buildable do
           workers: %{count: 10, level: 4}
         },
         produces: %{
-          education: %{5 => 10}
+          education_lvl_5: 10
         }
       },
       # RETAIL SHOPS ————————————————————————————————————
@@ -925,7 +927,20 @@ defmodule MayorGame.City.Buildable do
           health: -5,
           pollution: 10,
           sulfur: 1,
-          uranium: fn result -> if result, do: 1, else: 0 end
+          # fn _rng, _number_of_instances -> drop_amount
+          uranium: fn rng, number_of_buildables ->
+            # low-luck calculation at 0.001% chance, so rng needs only be used once
+            aggregate = number_of_buildables * 0.001
+            whole = floor(aggregate)
+            chance = aggregate - whole
+
+            whole +
+              if rng < chance do
+                1
+              else
+                0
+              end
+          end
           # gold: 1,
         }
       },
@@ -1129,8 +1144,10 @@ defmodule MayorGame.City.Buildable do
           workers: %{count: 10, level: 5}
         },
         produces: %{
-          missiles: 1,
-          missiles_capacity: 100
+          missiles: 1
+        },
+        stores: %{
+          missiles: 100
         }
       },
       # DEFENSE BASES ————————————————————————————————————
@@ -1146,8 +1163,10 @@ defmodule MayorGame.City.Buildable do
           workers: %{count: 10, level: 2}
         },
         produces: %{
-          shields: 1,
-          shields_capacity: 100
+          shields: 1
+        },
+        stores: %{
+          shields: 100
         }
       },
       # MISSILE DEFENSE ARRAY ————————————————————————————————————
@@ -1165,8 +1184,10 @@ defmodule MayorGame.City.Buildable do
           workers: %{count: 20, level: 5}
         },
         produces: %{
-          shields: 5,
-          shields_capacity: 200
+          shields: 5
+        },
+        stores: %{
+          shields: 200
         }
       }
     }

--- a/lib/mayor_game/city/buildable.ex
+++ b/lib/mayor_game/city/buildable.ex
@@ -5,6 +5,7 @@ defmodule MayorGame.City.Buildable do
   use Ecto.Schema
   import Ecto.Changeset
   alias MayorGame.City.{BuildableMetadata, Details}
+  alias MayorGame.Utility
   use Accessible
 
   @timestamps_opts [type: :utc_datetime]
@@ -785,9 +786,9 @@ defmodule MayorGame.City.Buildable do
         },
         # fn _rng, _number_of_instances -> drop_amount
         produces: %{
-          education: fn _rng, number_of_buildables ->
-            # simulate X dice rolls with chance 5%
-            round(Statistics.Distributions.Binomial.rand(number_of_buildables, 0.05))
+          education: fn rng, number_of_buildables ->
+            # low-luck calculation at 5% chance, so rng needs only be used once
+            Utility.dice_roll(number_of_buildables, 0.05)
           end
         }
       },
@@ -919,9 +920,9 @@ defmodule MayorGame.City.Buildable do
           pollution: 10,
           sulfur: 1,
           # fn _rng, _number_of_instances -> drop_amount
-          uranium: fn _rng, number_of_buildables ->
-            # simulate X dice rolls with chance 0.1%
-            round(Statistics.Distributions.Binomial.rand(number_of_buildables, 0.001))
+          uranium: fn rng, number_of_buildables ->
+            # low-luck calculation at 0.1% chance, so rng needs only be used once
+            Utility.dice_roll(number_of_buildables, 0.001)
           end
           # gold: 1,
         }

--- a/lib/mayor_game/city/buildable_metadata.ex
+++ b/lib/mayor_game/city/buildable_metadata.ex
@@ -13,6 +13,7 @@ defmodule MayorGame.City.BuildableMetadata do
     :capacity,
     :requires,
     :produces,
+    :stores,
     :multipliers,
     reason: [],
     enabled: false
@@ -30,6 +31,7 @@ defmodule MayorGame.City.BuildableMetadata do
           education_level: 1..5,
           capacity: integer | nil,
           produces: map | nil,
+          stores: map | nil,
           requires: map | nil,
           multipliers: map | nil,
           enabled: boolean,

--- a/lib/mayor_game/city/buildable_statistics.ex
+++ b/lib/mayor_game/city/buildable_statistics.ex
@@ -1,0 +1,28 @@
+defmodule MayorGame.City.BuildableStatistics do
+  use Accessible
+
+  # defaults to nil for keys without values
+  defstruct [
+    :title,
+    number: 0,
+    # fulfills reqs
+    operational: 0,
+    in_construction: 0,
+    workers_by_level: %{},
+    deficient_prereq_next: [],
+    deficient_prereq_all: [],
+    # precalc?
+    resource: %{}
+  ]
+
+  @type t :: %__MODULE__{
+          title: String.t(),
+          number: integer,
+          operational: integer,
+          in_construction: integer,
+          workers_by_level: %{integer => integer},
+          deficient_prereq_next: list(atom),
+          deficient_prereq_all: list(atom),
+          resource: %{atom => ResourceStatistics.t()}
+        }
+end

--- a/lib/mayor_game/city/citizens.ex
+++ b/lib/mayor_game/city/citizens.ex
@@ -41,7 +41,6 @@ defmodule MayorGame.City.Citizens do
       :name,
       :age,
       :education,
-      :has_job,
       :last_moved,
       :preferences
     ]

--- a/lib/mayor_game/city/resource_statistics.ex
+++ b/lib/mayor_game/city/resource_statistics.ex
@@ -1,0 +1,233 @@
+defmodule MayorGame.City.ResourceStatistics do
+  alias __MODULE__
+  use Accessible
+  alias MayorGame.City.{TownStatistics}
+  # education, unlike all other resources, uses a map
+  # this can complicate things quite a bit. We can make this struct work with maps but it may occur expensive checks for all resources, for the benefit of one resource
+  # for now, we split it to education_lvl_1, education_lvl_2 etc. And reserve a special education resource for libraries for random drop across all levels
+
+  defstruct [
+    :title,
+    stock: 0,
+    storage: nil,
+    production: 0,
+    consumption: 0,
+    droplist: []
+  ]
+
+  # fn _rng, _number_of_instances -> drop_amount
+  # fn _rng, _number_of_instances, _city -> drop_amount
+  @type dropfunction ::
+          (number, integer -> integer) | (number, integer, TownStatistics.t() -> integer) | nil
+
+  @type t :: %ResourceStatistics{
+          title: String.t(),
+          stock: integer,
+          storage: integer | nil,
+          production: integer,
+          consumption: integer,
+          droplist: list({integer, dropfunction})
+        }
+
+  @spec merge(ResourceStatistics.t(), ResourceStatistics.t(), integer) :: ResourceStatistics.t()
+  def merge(source, child, quantity \\ 1) do
+    %ResourceStatistics{
+      title: source.title,
+      stock: source.stock + child.stock * quantity,
+      storage:
+        if is_nil(source.storage) do
+          if is_nil(child.storage) do
+            nil
+          else
+            child.storage * quantity
+          end
+        else
+          if is_nil(child.storage) do
+            source.storage
+          else
+            source.storage + child.storage * quantity
+          end
+        end,
+      production: source.production + child.production * quantity,
+      consumption: source.consumption + child.consumption * quantity,
+      droplist:
+        if is_nil(source.droplist) do
+          []
+        else
+          source.droplist
+        end ++
+          if is_nil(child.droplist) do
+            []
+          else
+            List.flatten(List.duplicate(child.droplist, quantity))
+          end
+    }
+  end
+
+  @spec multiply(ResourceStatistics.t(), integer) :: ResourceStatistics.t()
+  def multiply(source, quantity \\ 1) do
+    %ResourceStatistics{
+      title: source.title,
+      stock: source.stock * quantity,
+      storage:
+        if is_nil(source.storage) do
+          nil
+        else
+          source.storage * quantity
+        end,
+      production: source.production * quantity,
+      consumption: source.consumption * quantity,
+      droplist: List.flatten(List.duplicate(source.droplist, quantity))
+    }
+  end
+
+  @spec fromProduces(String.t(), integer, integer | nil, list({integer, dropfunction})) ::
+          ResourceStatistics.t()
+  def fromProduces(title, value, storage \\ nil, droplist \\ []) do
+    %ResourceStatistics{
+      title: title,
+      stock: 0,
+      storage: storage,
+      production:
+        if value > 0 do
+          value
+        else
+          0
+        end,
+      consumption:
+        if value > 0 do
+          0
+        else
+          -value
+        end,
+      droplist:
+        if is_nil(droplist) do
+          []
+        else
+          droplist
+        end
+    }
+  end
+
+  @spec fromRequires(String.t(), integer, integer) :: ResourceStatistics.t()
+  def fromRequires(title, value, storage \\ nil) do
+    %ResourceStatistics{
+      title: title,
+      stock: 0,
+      storage:
+        if is_nil(storage) do
+          nil
+        else
+          -storage
+        end,
+      production:
+        if value > 0 do
+          0
+        else
+          -value
+        end,
+      consumption:
+        if value > 0 do
+          value
+        else
+          0
+        end,
+      droplist: []
+    }
+  end
+
+  @spec getStock(ResourceStatistics.t(), integer) :: integer
+  def getStock(stat, additive \\ 0) do
+    stat.stock + additive
+  end
+
+  @spec getStorage(ResourceStatistics.t()) :: integer | nil
+  def getStorage(stat) do
+    stat.storage
+  end
+
+  @spec getProduction(ResourceStatistics.t()) :: integer
+  def getProduction(stat) do
+    stat.production
+  end
+
+  @spec getConsumption(ResourceStatistics.t()) :: integer
+  def getConsumption(stat) do
+    stat.consumption
+  end
+
+  @spec getNextStock(ResourceStatistics.t()) :: integer
+  def getNextStock(stat) do
+    getStock(stat) + getNetProduction(stat)
+  end
+
+  @spec getNetProduction(ResourceStatistics.t()) :: integer
+  def getNetProduction(stat) do
+    stat.production - stat.consumption
+  end
+
+  @spec expressStock_SI(ResourceStatistics.t(), integer) :: String.t()
+  def expressStock_SI(stat, additive \\ 0) do
+    Number.SI.number_to_si(stat.stock + additive, precision: 3, trim: true)
+  end
+
+  @spec expressStockOverStorage_SI(ResourceStatistics.t(), integer) :: String.t()
+  def expressStockOverStorage_SI(stat, additive \\ 0) do
+    if is_nil(stat.storage) do
+      Number.SI.number_to_si(stat.stock + additive, precision: 3, trim: true)
+    else
+      Number.SI.number_to_si(stat.stock + additive, precision: 3, trim: true) <>
+        "/" <>
+        Number.SI.number_to_si(stat.storage, precision: 3, trim: true)
+    end
+  end
+
+  @spec expressProduction_SI(ResourceStatistics.t()) :: String.t()
+  def expressProduction_SI(stat) do
+    Number.SI.number_to_si(stat.production, precision: 3, trim: true)
+  end
+
+  @spec expressConsumption_SI(ResourceStatistics.t()) :: String.t()
+  def expressConsumption_SI(stat) do
+    Number.SI.number_to_si(stat.consumption, precision: 3, trim: true)
+  end
+
+  @spec expressNetProduction_SI(ResourceStatistics.t()) :: String.t()
+  def expressNetProduction_SI(stat) do
+    Number.SI.number_to_si(getNetProduction(stat), precision: 3, trim: true)
+  end
+
+  @spec expressAvailableOverSupply_SI(ResourceStatistics.t()) :: String.t()
+  def expressAvailableOverSupply_SI(stat) do
+    Number.SI.number_to_si(getNetProduction(stat), precision: 3, trim: true) <>
+      "/" <>
+      Number.SI.number_to_si(stat.production, precision: 3, trim: true)
+  end
+
+  @spec expressStock_delimited(ResourceStatistics.t(), integer) :: String.t()
+  def expressStock_delimited(stat, additive \\ 0) do
+    Number.Delimit.number_to_delimited(stat.stock + additive)
+  end
+
+  @spec expressStockOverStorage_delimited(ResourceStatistics.t(), integer) :: String.t()
+  def expressStockOverStorage_delimited(stat, additive \\ 0) do
+    if is_nil(stat.storage) do
+      Number.Delimit.number_to_delimited(stat.stock + additive)
+    else
+      Number.Delimit.number_to_delimited(stat.stock + additive) <>
+        "/" <>
+        Number.Delimit.number_to_delimited(stat.storage)
+    end
+  end
+
+  @spec expressNetProduction_delimited(ResourceStatistics.t()) :: String.t()
+  def expressNetProduction_delimited(stat) do
+    Number.Delimit.number_to_delimited(getNetProduction(stat))
+  end
+
+  @spec expressAvailableOverSupply_delimited(ResourceStatistics.t()) :: String.t()
+  def expressAvailableOverSupply_delimited(stat) do
+    Number.Delimit.number_to_delimited(getNetProduction(stat)) <>
+      "/" <> Number.Delimit.number_to_delimited(stat.production)
+  end
+end

--- a/lib/mayor_game/city/town_migration_statistics.ex
+++ b/lib/mayor_game/city/town_migration_statistics.ex
@@ -1,0 +1,58 @@
+defmodule MayorGame.City.TownMigrationStatistics do
+  alias __MODULE__
+  alias MayorGame.City.{Citizens}
+  use Accessible
+
+  defstruct [
+    :id,
+    :title,
+    aggregate_births: 0,
+    aggregate_deaths_by_age: 0,
+    aggregate_deaths_by_pollution: 0,
+    educated_citizens: %{0 => 0, 1 => 0, 2 => 0, 3 => 0, 4 => 0, 5 => 0},
+    housing_left: 0,
+    staying_citizens: [],
+    migrating_citizens_due_to_tax: [],
+    migrating_citizens: [],
+    unemployed_citizens: [],
+    unhoused_citizens: [],
+    polluted_citizens: []
+  ]
+
+  @type t ::
+          %TownMigrationStatistics{
+            # City
+            id: integer | nil,
+            title: String.t(),
+            aggregate_births: integer,
+            aggregate_deaths_by_age: integer,
+            aggregate_deaths_by_pollution: integer,
+            educated_citizens: %{integer => integer},
+            housing_left: integer,
+            staying_citizens: list(Citizens.t()),
+            migrating_citizens_due_to_tax: list(Citizens.t()),
+            migrating_citizens: list(Citizens.t()),
+            unemployed_citizens: list(Citizens.t()),
+            unhoused_citizens: list(Citizens.t()),
+            polluted_citizens: list(Citizens.t())
+          }
+
+  @spec fromTown(Town.t()) :: TownMigrationStatistics.t()
+  def fromTown(town) do
+    %TownMigrationStatistics{
+      id: town.id,
+      title: town.title,
+      aggregate_births: 0,
+      aggregate_deaths_by_age: 0,
+      aggregate_deaths_by_pollution: 0,
+      educated_citizens: %{0 => 0, 1 => 0, 2 => 0, 3 => 0, 4 => 0, 5 => 0},
+      housing_left: 0,
+      staying_citizens: [],
+      migrating_citizens_due_to_tax: [],
+      migrating_citizens: [],
+      unemployed_citizens: [],
+      unhoused_citizens: [],
+      polluted_citizens: []
+    }
+  end
+end

--- a/lib/mayor_game/city/town_statistics.ex
+++ b/lib/mayor_game/city/town_statistics.ex
@@ -1,0 +1,150 @@
+defmodule MayorGame.City.TownStatistics do
+  alias __MODULE__
+  alias MayorGame.City.{ResourceStatistics, BuildableStatistics}
+  alias MayorGame.Rules
+  use Accessible
+
+  defstruct [
+    :id,
+    :title,
+    :region,
+    :climate,
+    :season,
+    :user,
+    :patron,
+    :contributor,
+    :priorities,
+    :tax_rates,
+    :jobs_by_level,
+    :vacancies_by_level,
+    :total_citizens,
+    :citizen_count_by_level,
+    :employed_citizen_count_by_level,
+    :resource_stats,
+    :buildable_stats
+  ]
+
+  @type t ::
+          %TownStatistics{
+            # City
+            id: integer | nil,
+            title: String.t(),
+            region: String.t(),
+            climate: String.t(),
+
+            # World
+            season: atom,
+
+            # user stats
+            user: %MayorGame.Auth.User{},
+            patron: integer,
+            contributor: boolean,
+
+            # controls in City
+            priorities: %{String.t() => integer},
+            tax_rates: %{integer => number},
+
+            # objects in City
+            jobs_by_level: %{integer => integer},
+            vacancies_by_level: %{integer => integer},
+            total_citizens: integer,
+            citizen_count_by_level: %{integer => integer},
+            employed_citizen_count_by_level: %{integer => integer},
+
+            # changes
+            resource_stats: %{atom => ResourceStatistics.t()},
+            buildable_stats: %{atom => BuildableStatistics.t()}
+          }
+
+  @spec fromTown(Town.t(), World.t()) :: TownStatistics.t()
+  def fromTown(town, world) do
+    %TownStatistics{
+      id: town.id,
+      title: town.title,
+      region: town.region,
+      climate: town.climate,
+      season: Rules.season_from_day(world.day),
+      user: town.user,
+      patron: town.patron,
+      contributor: town.contributor,
+      priorities: town.priorities,
+      tax_rates: town.tax_rates,
+      jobs_by_level: %{0 => 0, 1 => 0, 2 => 0, 3 => 0, 4 => 0, 5 => 0},
+      vacancies_by_level: %{0 => 0, 1 => 0, 2 => 0, 3 => 0, 4 => 0, 5 => 0},
+      total_citizens: length(town.citizens_blob),
+      citizen_count_by_level: Enum.frequencies_by(town.citizens_blob, & &1["education"]),
+      employed_citizen_count_by_level: %{},
+      resource_stats: %{
+        :money => %ResourceStatistics{
+          title: "money",
+          stock: town.treasury,
+          storage: nil,
+          production: 0,
+          consumption: 0
+        },
+        :housing => %ResourceStatistics{
+          title: "housing",
+          stock: 0,
+          storage: nil,
+          production: 0,
+          consumption: 0
+        },
+        :steel => %ResourceStatistics{
+          title: "steel",
+          stock: town.steel,
+          storage: nil,
+          production: 0,
+          consumption: 0
+        },
+        :uranium => %ResourceStatistics{
+          title: "uranium",
+          stock: town.uranium,
+          storage: nil,
+          production: 0,
+          consumption: 0
+        },
+        :gold => %ResourceStatistics{
+          title: "gold",
+          stock: town.gold,
+          storage: nil,
+          production: 0,
+          consumption: 0
+        },
+        :sulfur => %ResourceStatistics{
+          title: "sulfur",
+          stock: town.sulfur,
+          storage: nil,
+          production: 0,
+          consumption: 0
+        },
+        :shields => %ResourceStatistics{
+          title: "shields",
+          stock: town.shields,
+          storage: nil,
+          production: 0,
+          consumption: 0
+        },
+        :missiles => %ResourceStatistics{
+          title: "missiles",
+          stock: town.missiles,
+          storage: nil,
+          production: 0,
+          consumption: 0
+        }
+      },
+      buildable_stats: %{}
+    }
+  end
+
+  @spec getResource(TownStatistics.t(), atom) :: ResourceStatistics.t()
+  def getResource(town_stats, resource) do
+    # fetch the resource stat from this struct. If it is not found, return an empty one
+    Map.get(town_stats.resource_stats, resource, %MayorGame.City.ResourceStatistics{})
+  end
+
+  @spec getBuildable(TownStatistics.t(), atom) :: BuildableStatistics.t()
+  def getBuildable(town_stats, buildable) do
+    # fetch the buildable stat from this struct. If it is not found, return an empty one
+    Map.get(town_stats.buildable_stats, buildable, %MayorGame.City.BuildableStatistics{})
+  end
+end

--- a/lib/mayor_game/city_calculator/city_migrator.ex
+++ b/lib/mayor_game/city_calculator/city_migrator.ex
@@ -1,7 +1,7 @@
 defmodule MayorGame.CityMigrator do
   use GenServer, restart: :permanent
-  alias MayorGame.City.{Town, Citizens, Buildable}
-  alias MayorGame.{City, CityHelpers, Repo}
+  alias MayorGame.City.{Town, Citizens, Buildable, TownStatistics, ResourceStatistics}
+  alias MayorGame.{City, CityHelpers, Repo, Rules}
   import Ecto.Query
 
   def start_link(initial_val) do
@@ -55,569 +55,475 @@ defmodule MayorGame.CityMigrator do
           migration_tick: migration_tick
         } = _sent_map
       ) do
-    # filter for
-    cities = City.list_cities_preload() |> Enum.filter(fn city -> length(city.citizens_blob) >= 20 end)
+    # profiling
+    {:ok, datetime_pre} = DateTime.now("Etc/UTC")
 
-    # cities_count = Enum.count(cities)
+    # filter for
+    cities =
+      City.list_cities_preload() |> Enum.filter(fn city -> length(city.citizens_blob) >= 20 end)
 
     pollution_ceiling = 2_000_000_000 * Random.gammavariate(7.5, 1)
 
     db_world = City.get_world!(1)
 
-    season =
-      cond do
-        rem(db_world.day, 365) < 91 -> :winter
-        rem(db_world.day, 365) < 182 -> :spring
-        rem(db_world.day, 365) < 273 -> :summer
-        true -> :fall
-      end
+    if length(cities) > 0 do
+      season = Rules.season_from_day(db_world.day)
 
-    cities_list = Enum.shuffle(cities)
+      cities_list = Enum.shuffle(cities)
 
-    time_to_learn = if in_dev, do: rem(migration_tick, 10) == 0, else: rem(migration_tick, 90) == 0
+      time_to_learn =
+        if in_dev, do: rem(migration_tick, 10) == 0, else: rem(migration_tick, 90) == 0
 
-    leftovers =
-      cities_list
-      |> Enum.map(fn city ->
-        # result here is a %Town{} with stats calculated
-        CityHelpers.calculate_city_stats(
-          city,
-          db_world,
-          pollution_ceiling,
-          season,
-          buildables_map,
-          in_dev,
-          time_to_learn
-        )
-      end)
-
-    employed_looking_citizens = List.flatten(Enum.map(leftovers, fn city -> city.employed_looking_citizens end))
-
-    unemployed_citizens = List.flatten(Enum.map(leftovers, fn city -> city.unemployed_citizens end))
-
-    unhoused_citizens = List.flatten(Enum.map(leftovers, fn city -> city.unhoused_citizens end))
-    # new_world_pollution = Enum.sum(Enum.map(leftovers, fn city -> city.pollution end))
-    # total_housing_slots = Enum.sum(Enum.map(leftovers, fn city -> city.housing_left end))
-
-    housing_slots = Enum.map(leftovers, fn city -> {city.id, city.housing_left} end) |> Map.new()
-    # ok this is still good
-
-    sprawl_max = Enum.max(Enum.map(leftovers, fn city -> city.sprawl end))
-    pollution_max = Enum.max(Enum.map(leftovers, fn city -> city.pollution end))
-    pollution_min = Enum.min(Enum.map(leftovers, fn city -> city.pollution end))
-    pollution_spread = pollution_max - pollution_min
-    fun_max = Enum.max(Enum.map(leftovers, fn city -> city.fun end))
-    health_max = Enum.max(Enum.map(leftovers, fn city -> city.health end))
-    health_min = Enum.min(Enum.map(leftovers, fn city -> city.health end))
-    health_spread = health_max - health_min
-
-    home_city_advantage = 0.05
-
-    slotted_cities_by_id =
-      leftovers
-      |> Enum.map(fn city ->
-        normalize_city(
-          city,
-          fun_max,
-          health_spread,
-          pollution_spread,
-          sprawl_max
-        )
-      end)
-      |> Map.new(fn city ->
-        {city.id, city}
-      end)
-
-    city_preference_scores =
-      Enum.map(1..10, fn x ->
-        {x,
-         Enum.map(0..5, fn edu_level ->
-           {edu_level,
-            Enum.map(slotted_cities_by_id, fn {id, city} ->
-              {id,
-               Float.round(
-                 citizen_score(
-                   Citizens.preset_preferences()[x],
-                   edu_level,
-                   city
-                 ),
-                 4
-               )}
-            end)
-            |> Enum.into(%{})}
-         end)
-         |> Enum.into(%{})}
-      end)
-      |> Enum.into(%{})
-
-    # jobs still valid here
-    # and housing
-
-    updated_citizens_by_id =
-      leftovers
-      |> Map.new(fn city -> {city.id, city.housed_employed_staying_citizens} end)
-
-    # for each city
-    # add an aempty list
-    # first put staying citizens
-    # then push other citizens into it
-    # unemployed_citizens: [],
-    # housed_employed_staying_citizens: [],
-    # employed_looking_citizens: [],
-    # unhoused_citizens: [],
-
-    # ——————————————————————————————————————————————————————————————————————————————————
-    # ————————————————————————————————————————— ROUND 1: MOVE CITIZENS PER JOB LEVEL
-    # ——————————————————————————————————————————————————————————————————————————————————
-
-    level_slots =
-      Map.new(0..5, fn x ->
-        {x, %{normalized_cities: %{}, job_and_housing_slots: 0, job_and_housing_slots_expanded: []}}
-      end)
-
-    # sets up empty map for below function
-    # SHAPE OF BELOW:
-    # %{
-    #   1: %{normalized_cities: [
-    #     {city_normalized, # of slots}, {city_normalized, # of slots}
-    #   ],
-    #     total_slots: int,
-    #     job_and_housing_slots_expanded: list of slots
-    #   }
-    # }
-    # all_cities_by_id = maybe make a map here of city in all_cities_new and their id
-    # or all_cities_new might already be that, by index
-    # or the map is just of the ones with housing slots (e.g. in housing_slots)
-    # all_cities_by_id =
-    #   leftovers
-    #   |> Map.new(fn city -> {city.id, city} end)
-
-    # NO FLOW
-
-    # housing_slots is a list of {city, number of slots}
-    # try FLOW here with a partition + reduce
-    # do a bunch of the housing calcs with ETS? instead of mapping over a map accumulator, put it in ets and manipulate it there?
-
-    job_and_housing_slots_normalized =
-      Enum.reduce(
-        housing_slots,
-        level_slots,
-        fn {normalized_city_id, housing_slots_count}, acc ->
-          slots_per_level =
-            Enum.reduce(
-              slotted_cities_by_id[normalized_city_id].jobs,
-              %{housing_slots_left: housing_slots_count},
-              fn {level, count}, acc2 ->
-                if acc2.housing_slots_left > 0 do
-                  level_slots_count = min(count, acc2.housing_slots_left)
-
-                  acc2
-                  |> Map.update!(
-                    :housing_slots_left,
-                    &(&1 - level_slots_count)
-                  )
-                  |> Map.put(level, {normalized_city_id, level_slots_count})
-                else
-                  acc2
-                  |> Map.put(level, {normalized_city_id, 0})
-                end
-              end
+      leftovers =
+        cities_list
+        |> Enum.map(fn city ->
+          # result here is a %Town{} with stats calculated
+          city_stat =
+            CityHelpers.calculate_city_stats_with_drops(
+              city,
+              db_world,
+              pollution_ceiling,
+              season,
+              buildables_map,
+              in_dev,
+              time_to_learn
             )
-            |> Map.drop([:housing_slots_left])
 
-          # each value is [{city, count}]
-          # slots_taken_w_job = Enum.sum(Map.values(slots_per_level))
-          # slots_taken_w_job = Enum.sum(Keyword.values(Map.values(slots_per_level)))
+          leftover =
+            CityHelpers.calculate_citizen_stats(
+              city,
+              city_stat,
+              db_world,
+              pollution_ceiling,
+              season,
+              buildables_map,
+              in_dev,
+              time_to_learn
+            )
 
-          # for each level in slots_per_level
-          #
-          level_results =
-            Enum.map(5..0, fn x ->
-              {x,
-               %{
-                 normalized_cities:
-                   Map.put(
-                     acc[x].normalized_cities,
-                     elem(slots_per_level[x], 0),
-                     elem(slots_per_level[x], 1)
-                   ),
+          # combine town and the calculated stats (TownStatistics + TownMigrationStatistics)
+          city |> Map.merge(city_stat) |> Map.merge(leftover)
+        end)
 
-                 #  acc[x].normalized_cities ++ [slots_per_level[x]],
-                 job_and_housing_slots: acc[x].job_and_housing_slots + elem(slots_per_level[x], 1),
-                 job_and_housing_slots_expanded:
-                   if elem(slots_per_level[x], 1) > 0 do
-                     acc[x].job_and_housing_slots_expanded ++
-                       Enum.map(1..elem(slots_per_level[x], 1), fn _ -> normalized_city_id end)
-                   else
-                     acc[x].job_and_housing_slots_expanded
-                   end
-               }}
-            end)
-            |> Enum.into(%{})
-
-          level_results
-        end
-      )
-
-    # split by who will get to take the good slots
-    # shape is map with key level, tuple
-    # %{
-    #   0 => {[citizens_searching], [citizens_not]},
-    #   1 => {[citizens_searching], [citizens_not]},
-    # }
-    employed_citizens_split =
-      Map.new(5..0, fn x ->
-        {x,
-         Enum.split(
-           Enum.filter(employed_looking_citizens, fn cit -> cit["education"] == x end),
-           job_and_housing_slots_normalized[x].job_and_housing_slots
-         )}
-      end)
-
-    preferred_locations_by_level =
-      Map.new(5..0, fn level ->
-        {level,
-         Enum.reduce(
-           elem(employed_citizens_split[level], 0),
-           %{
-             choices: [],
-             slots: job_and_housing_slots_normalized[level].normalized_cities
-           },
-           fn citizen, acc ->
-             current_city_score =
-               city_preference_scores[citizen["preferences"]][citizen["education"]][
-                 citizen["town_id"]
-               ]
-
-             chosen_city =
-               Enum.reduce(
-                 acc.slots,
-                 %{chosen_id: citizen["town_id"], top_score: -1},
-                 fn {city_id, count}, acc2 ->
-                   score =
-                     if count > 0 do
-                       city_preference_scores[citizen["preferences"]][citizen["education"]][
-                         city_id
-                       ]
-                     else
-                       0
-                     end
-
-                   if score > acc2.top_score && score > current_city_score + home_city_advantage do
-                     %{
-                       chosen_id: city_id,
-                       top_score: score
-                     }
-                   else
-                     acc2
-                   end
-                 end
-               )
-
-             updated_slots =
-               acc.slots
-               |> Map.update(chosen_city.chosen_id, 0, &(&1 - 1))
-               |> Map.update(citizen["town_id"], 0, &(&1 + 1))
-
-             %{
-               choices: [{citizen, chosen_city.chosen_id} | acc.choices],
-               slots: updated_slots
-             }
-           end
-         )}
-      end)
-
-    # find a way to return these to origin city
-    looking_but_not_in_job_race =
-      Enum.reduce(employed_citizens_split, [], fn {_k, v}, acc ->
-        List.flatten([elem(v, 1) | acc])
-      end)
-
-    # ^ array of citizens who are still looking, that didn't make it into the level-specific comparisons
-
-    # update the citizen's choice
-    updated_citizens_by_id_2 =
-      Enum.reduce(5..0, updated_citizens_by_id, fn x, acc ->
-        if preferred_locations_by_level[x].choices != [] do
-          Enum.reduce(preferred_locations_by_level[x].choices, acc, fn {citizen, chosen_city_id}, acc2 ->
-            if citizen["town_id"] != chosen_city_id do
-              acc2
-              |> Map.update!(
-                chosen_city_id,
-                &[
-                  citizen
-                  |> Map.take(["education", "preferences", "last_moved", "age"])
-                  |> Map.put("last_moved", db_world.day)
-                  | &1
-                ]
-              )
-            else
-              acc2
-              |> Map.update!(
-                chosen_city_id,
-                &[citizen |> Map.take(["education", "preferences", "last_moved", "age"]) | &1]
-              )
-            end
+      employed_looking_citizens =
+        List.flatten(
+          Enum.map(leftovers, fn city ->
+            city.migrating_citizens ++ city.migrating_citizens_due_to_tax
           end)
-        else
-          acc
-        end
-      end)
+        )
 
-    # add non-lookers back
-    updated_citizens_by_id_3 =
-      if looking_but_not_in_job_race != [] do
-        Enum.reduce(looking_but_not_in_job_race, updated_citizens_by_id_2, fn citizen, acc ->
-          acc
-          |> Map.update!(
-            citizen["town_id"],
-            &[citizen |> Map.take(["education", "preferences", "last_moved", "age"]) | &1]
+      unemployed_citizens =
+        List.flatten(Enum.map(leftovers, fn city -> city.unemployed_citizens end))
+
+      unhoused_citizens = List.flatten(Enum.map(leftovers, fn city -> city.unhoused_citizens end))
+      # new_world_pollution = Enum.sum(Enum.map(leftovers, fn city -> city.pollution end))
+      # total_housing_slots = Enum.sum(Enum.map(leftovers, fn city -> city.housing_left end))
+
+      housing_slots =
+        Enum.map(leftovers, fn city -> {city.id, city.housing_left} end) |> Map.new()
+
+      # ok this is still good
+
+      sprawl_max =
+        Enum.max(
+          Enum.map(leftovers, fn city ->
+            city |> TownStatistics.getResource(:sprawl) |> ResourceStatistics.getNetProduction()
+          end)
+        )
+
+      pollution_enum =
+        Enum.map(leftovers, fn city ->
+          city |> TownStatistics.getResource(:pollution) |> ResourceStatistics.getNetProduction()
+        end)
+
+      pollution_max = Enum.max(pollution_enum)
+      pollution_min = Enum.min(pollution_enum)
+      pollution_spread = pollution_max - pollution_min
+
+      fun_max =
+        Enum.max(
+          Enum.map(leftovers, fn city ->
+            city |> TownStatistics.getResource(:fun) |> ResourceStatistics.getNetProduction()
+          end)
+        )
+
+      health_enum =
+        Enum.map(leftovers, fn city ->
+          city |> TownStatistics.getResource(:health) |> ResourceStatistics.getNetProduction()
+        end)
+
+      health_max = Enum.max(health_enum)
+      health_min = Enum.min(health_enum)
+      health_spread = health_max - health_min
+
+      home_city_advantage = 0.05
+
+      slotted_cities_by_id =
+        leftovers
+        |> Enum.map(fn city ->
+          normalize_city(
+            city,
+            fun_max,
+            health_spread,
+            pollution_spread,
+            sprawl_max
           )
         end)
-      else
-        updated_citizens_by_id_2
-      end
+        |> Map.new(fn city ->
+          {city.id, city}
+        end)
 
-    vacated_slots =
-      Enum.flat_map(preferred_locations_by_level, fn {_level, preferred_locations} ->
-        preferred_locations.choices
-        |> Enum.filter(fn {citizen, city_id} -> citizen["town_id"] != city_id end)
-        |> Enum.map(fn {citizen, _city_id} -> citizen["town_id"] end)
-      end)
+      city_preference_scores =
+        Enum.map(1..10, fn x ->
+          {x,
+           Enum.map(0..5, fn edu_level ->
+             {edu_level,
+              Enum.map(slotted_cities_by_id, fn {id, city} ->
+                {id,
+                 Float.round(
+                   citizen_score(
+                     Citizens.preset_preferences()[x],
+                     edu_level,
+                     city
+                   ),
+                   4
+                 )}
+              end)
+              |> Enum.into(%{})}
+           end)
+           |> Enum.into(%{})}
+        end)
+        |> Enum.into(%{})
 
-    occupied_slots =
-      Enum.flat_map(preferred_locations_by_level, fn {_level, preferred_locations} ->
-        preferred_locations.choices
-        |> Enum.filter(fn {citizen, city_id} -> citizen["town_id"] != city_id end)
-        |> Enum.map(fn {_citizen, city_id} -> city_id end)
-      end)
+      # jobs still valid here
+      # and housing
 
-    vacated_freq = Enum.frequencies(vacated_slots)
-    occupied_freq = Enum.frequencies(occupied_slots)
+      updated_citizens_by_id =
+        leftovers
+        |> Map.new(fn city -> {city.id, city.staying_citizens} end)
 
-    housing_slots_2 =
-      housing_slots
-      |> Map.merge(vacated_freq, fn _k, v1, v2 -> v1 + v2 end)
-      |> Map.merge(occupied_freq, fn _k, v1, v2 -> v1 - v2 end)
+      # the TownMigrationStatistics part of the map contains all categorized citizens
+      # Those that take part in migration are
+      #   migrating_citizens_due_to_tax: [],
+      #   migrating_citizens: [],
+      #   unemployed_citizens: [],
+      #   unhoused_citizens: [],
 
-    # NEW UNEMPLOYED CODE ————————————————————————————————————————————————————————————————————————————
-    # ————————————————————————————————————————————————————————————————————————————
-    # ————————————————————————————————————————————————————————————————————————————
-    # ————————————————————————————————————————————————————————————————————————————
-    # ————————————————————————————————————————————————————————————————————————————
+      # ——————————————————————————————————————————————————————————————————————————————————
+      # ————————————————————————————————————————— ROUND 1: MOVE CITIZENS PER JOB LEVEL
+      # ——————————————————————————————————————————————————————————————————————————————————
 
-    unemployed_citizens_split =
-      Map.new(5..0, fn x ->
-        {x,
-         Enum.split(
-           Enum.filter(unemployed_citizens, fn cit -> cit["education"] == x end),
-           Enum.sum(Map.values(preferred_locations_by_level[x].slots))
-         )}
-      end)
+      level_slots =
+        Map.new(0..5, fn x ->
+          {x,
+           %{normalized_cities: %{}, job_and_housing_slots: 0, job_and_housing_slots_expanded: []}}
+        end)
 
-    unemployed_preferred_locations_by_level =
-      Map.new(5..0, fn level ->
-        {level,
-         Enum.reduce(
-           elem(unemployed_citizens_split[level], 0),
-           %{
-             choices: [],
-             slots: preferred_locations_by_level[level].slots
-           },
-           fn citizen, acc ->
-             chosen_city =
-               Enum.reduce(
-                 acc.slots,
+      # sets up empty map for below function
+      # SHAPE OF BELOW:
+      # %{
+      #   1: %{normalized_cities: [
+      #     {city_normalized, # of slots}, {city_normalized, # of slots}
+      #   ],
+      #     total_slots: int,
+      #     job_and_housing_slots_expanded: list of slots
+      #   }
+      # }
+      # all_cities_by_id = maybe make a map here of city in all_cities_new and their id
+      # or all_cities_new might already be that, by index
+      # or the map is just of the ones with housing slots (e.g. in housing_slots)
+      # all_cities_by_id =
+      #   leftovers
+      #   |> Map.new(fn city -> {city.id, city} end)
+
+      # NO FLOW
+
+      # housing_slots is a list of {city, number of slots}
+      # try FLOW here with a partition + reduce
+      # do a bunch of the housing calcs with ETS? instead of mapping over a map accumulator, put it in ets and manipulate it there?
+
+      job_and_housing_slots_normalized =
+        Enum.reduce(
+          housing_slots,
+          level_slots,
+          fn {normalized_city_id, housing_slots_count}, acc ->
+            slots_per_level =
+              Enum.reduce(
+                slotted_cities_by_id[normalized_city_id].jobs,
+                %{housing_slots_left: housing_slots_count},
+                fn {level, count}, acc2 ->
+                  if acc2.housing_slots_left > 0 do
+                    level_slots_count = min(count, acc2.housing_slots_left)
+
+                    acc2
+                    |> Map.update!(
+                      :housing_slots_left,
+                      &(&1 - level_slots_count)
+                    )
+                    |> Map.put(level, {normalized_city_id, level_slots_count})
+                  else
+                    acc2
+                    |> Map.put(level, {normalized_city_id, 0})
+                  end
+                end
+              )
+              |> Map.drop([:housing_slots_left])
+
+            # each value is [{city, count}]
+            # slots_taken_w_job = Enum.sum(Map.values(slots_per_level))
+            # slots_taken_w_job = Enum.sum(Keyword.values(Map.values(slots_per_level)))
+
+            # for each level in slots_per_level
+            #
+            level_results =
+              Enum.map(5..0, fn x ->
+                {x,
                  %{
-                   chosen_id: citizen["town_id"],
-                   top_score: -1
-                 },
-                 fn {city_id, count}, acc2 ->
-                   score =
-                     if count > 0 && city_id != citizen["town_id"] do
-                       city_preference_scores[citizen["preferences"]][citizen["education"]][
-                         city_id
-                       ]
+                   normalized_cities:
+                     Map.put(
+                       acc[x].normalized_cities,
+                       elem(slots_per_level[x], 0),
+                       elem(slots_per_level[x], 1)
+                     ),
+
+                   #  acc[x].normalized_cities ++ [slots_per_level[x]],
+                   job_and_housing_slots:
+                     acc[x].job_and_housing_slots + elem(slots_per_level[x], 1),
+                   job_and_housing_slots_expanded:
+                     if elem(slots_per_level[x], 1) > 0 do
+                       acc[x].job_and_housing_slots_expanded ++
+                         Enum.map(1..elem(slots_per_level[x], 1), fn _ -> normalized_city_id end)
                      else
-                       0
+                       acc[x].job_and_housing_slots_expanded
                      end
+                 }}
+              end)
+              |> Enum.into(%{})
 
-                   if score > acc2.top_score do
-                     %{
-                       chosen_id: city_id,
-                       top_score: score
-                     }
-                   else
-                     acc2
-                   end
-                 end
-               )
+            level_results
+          end
+        )
 
-             updated_slots =
-               acc.slots
-               |> Map.update(chosen_city.chosen_id, 0, &(&1 - 1))
+      # split by who will get to take the good slots
+      # shape is map with key level, tuple
+      # %{
+      #   0 => {[citizens_searching], [citizens_not]},
+      #   1 => {[citizens_searching], [citizens_not]},
+      # }
+      employed_citizens_split =
+        Map.new(5..0, fn x ->
+          {x,
+           Enum.split(
+             Enum.filter(employed_looking_citizens, fn cit -> cit["education"] == x end),
+             job_and_housing_slots_normalized[x].job_and_housing_slots
+           )}
+        end)
 
+      preferred_locations_by_level =
+        Map.new(5..0, fn level ->
+          {level,
+           Enum.reduce(
+             elem(employed_citizens_split[level], 0),
              %{
-               choices: [{citizen, chosen_city.chosen_id} | acc.choices],
-               slots: updated_slots
-             }
-           end
-         )}
-      end)
+               choices: [],
+               slots: job_and_housing_slots_normalized[level].normalized_cities
+             },
+             fn citizen, acc ->
+               current_city_score =
+                 city_preference_scores[citizen["preferences"]][citizen["education"]][
+                   citizen["town_id"]
+                 ]
 
-    # find a way to return these to origin city
-    unemployed_split_2 =
-      Enum.reduce(unemployed_citizens_split, [], fn {_k, v}, acc ->
-        List.flatten([elem(v, 1) | acc])
-      end)
+               chosen_city =
+                 Enum.reduce(
+                   acc.slots,
+                   %{chosen_id: citizen["town_id"], top_score: -1},
+                   fn {city_id, count}, acc2 ->
+                     score =
+                       if count > 0 do
+                         city_preference_scores[citizen["preferences"]][citizen["education"]][
+                           city_id
+                         ]
+                       else
+                         0
+                       end
 
-    # update the citizen's choice
-    updated_citizens_by_id_4 =
-      Enum.reduce(5..0, updated_citizens_by_id_3, fn x, acc ->
-        # if unemployed_preferred_locations_by_level[x].choices != [] do
-        Enum.reduce(unemployed_preferred_locations_by_level[x].choices, acc, fn {citizen, chosen_city_id}, acc2 ->
-          if citizen["town_id"] != chosen_city_id do
-            acc2
-            |> Map.update!(
-              chosen_city_id,
-              &[
-                citizen
-                |> Map.take(["education", "preferences", "last_moved", "age"])
-                |> Map.put("last_moved", db_world.day)
-                | &1
-              ]
-            )
+                     if score > acc2.top_score && score > current_city_score + home_city_advantage do
+                       %{
+                         chosen_id: city_id,
+                         top_score: score
+                       }
+                     else
+                       acc2
+                     end
+                   end
+                 )
+
+               updated_slots =
+                 acc.slots
+                 |> Map.update(chosen_city.chosen_id, 0, &(&1 - 1))
+                 |> Map.update(citizen["town_id"], 0, &(&1 + 1))
+
+               %{
+                 choices: [{citizen, chosen_city.chosen_id} | acc.choices],
+                 slots: updated_slots
+               }
+             end
+           )}
+        end)
+
+      # find a way to return these to origin city
+      looking_but_not_in_job_race =
+        Enum.reduce(employed_citizens_split, [], fn {_k, v}, acc ->
+          List.flatten([elem(v, 1) | acc])
+        end)
+
+      # ^ array of citizens who are still looking, that didn't make it into the level-specific comparisons
+
+      # update the citizen's choice
+      updated_citizens_by_id_2 =
+        Enum.reduce(5..0, updated_citizens_by_id, fn x, acc ->
+          if preferred_locations_by_level[x].choices != [] do
+            Enum.reduce(preferred_locations_by_level[x].choices, acc, fn {citizen, chosen_city_id},
+                                                                         acc2 ->
+              if citizen["town_id"] != chosen_city_id do
+                acc2
+                |> Map.update!(
+                  chosen_city_id,
+                  &[
+                    citizen
+                    |> Map.take(["education", "preferences", "last_moved", "age"])
+                    |> Map.put("last_moved", db_world.day)
+                    | &1
+                  ]
+                )
+              else
+                acc2
+                |> Map.update!(
+                  chosen_city_id,
+                  &[citizen |> Map.take(["education", "preferences", "last_moved", "age"]) | &1]
+                )
+              end
+            end)
           else
-            acc2
-            |> Map.update!(
-              chosen_city_id,
-              &[citizen |> Map.take(["education", "preferences", "last_moved", "age"]) | &1]
-            )
+            acc
           end
         end)
 
-        # else
-        # acc
-        # end
-      end)
+      # add non-lookers back
+      updated_citizens_by_id_3 =
+        if looking_but_not_in_job_race != [] do
+          Enum.reduce(looking_but_not_in_job_race, updated_citizens_by_id_2, fn citizen, acc ->
+            acc
+            |> Map.update!(
+              citizen["town_id"],
+              &[citizen |> Map.take(["education", "preferences", "last_moved", "age"]) | &1]
+            )
+          end)
+        else
+          updated_citizens_by_id_2
+        end
 
-    # add non-lookers back
-    updated_citizens_by_id_5 =
-      if unemployed_split_2 != [] do
-        Enum.reduce(unemployed_split_2, updated_citizens_by_id_4, fn citizen, acc ->
-          acc
-          |> Map.update!(
-            citizen["town_id"],
-            &[
-              citizen |> Map.take(["education", "preferences", "last_moved", "age"]) | &1
-            ]
-          )
+      vacated_slots =
+        Enum.flat_map(preferred_locations_by_level, fn {_level, preferred_locations} ->
+          preferred_locations.choices
+          |> Enum.filter(fn {citizen, city_id} -> citizen["town_id"] != city_id end)
+          |> Enum.map(fn {citizen, _city_id} -> citizen["town_id"] end)
         end)
-      else
-        updated_citizens_by_id_4
-      end
 
-    vacated_slots_2 =
-      Enum.flat_map(unemployed_preferred_locations_by_level, fn {_level, preferred_locations} ->
-        preferred_locations.choices
-        |> Enum.filter(fn {citizen, city_id} -> citizen["town_id"] != city_id end)
-        |> Enum.map(fn {citizen, _city_id} -> citizen["town_id"] end)
-      end)
+      occupied_slots =
+        Enum.flat_map(preferred_locations_by_level, fn {_level, preferred_locations} ->
+          preferred_locations.choices
+          |> Enum.filter(fn {citizen, city_id} -> citizen["town_id"] != city_id end)
+          |> Enum.map(fn {_citizen, city_id} -> city_id end)
+        end)
 
-    occupied_slots_2 =
-      Enum.flat_map(unemployed_preferred_locations_by_level, fn {_level, preferred_locations} ->
-        preferred_locations.choices
-        |> Enum.filter(fn {citizen, city_id} -> citizen["town_id"] != city_id end)
-        |> Enum.map(fn {_citizen, city_id} -> city_id end)
-      end)
+      vacated_freq = Enum.frequencies(vacated_slots)
+      occupied_freq = Enum.frequencies(occupied_slots)
 
-    vacated_freq_2 = Enum.frequencies(vacated_slots_2)
-    occupied_freq_2 = Enum.frequencies(occupied_slots_2)
+      housing_slots_2 =
+        housing_slots
+        |> Map.merge(vacated_freq, fn _k, v1, v2 -> v1 + v2 end)
+        |> Map.merge(occupied_freq, fn _k, v1, v2 -> v1 - v2 end)
 
-    housing_slots_3 =
-      housing_slots_2
-      |> Map.merge(vacated_freq_2, fn _k, v1, v2 -> v1 + v2 end)
-      |> Map.merge(occupied_freq_2, fn _k, v1, v2 -> v1 - v2 end)
+      # NEW UNEMPLOYED CODE ————————————————————————————————————————————————————————————————————————————
+      # ————————————————————————————————————————————————————————————————————————————
+      # ————————————————————————————————————————————————————————————————————————————
+      # ————————————————————————————————————————————————————————————————————————————
+      # ————————————————————————————————————————————————————————————————————————————
 
-    # NEW UNHOUSED CODE —————————————————————————————————————————————————————————————
-    # ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
-    # ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
-    # ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
-    # ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
-    # ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      unemployed_citizens_split =
+        Map.new(5..0, fn x ->
+          {x,
+           Enum.split(
+             Enum.filter(unemployed_citizens, fn cit -> cit["education"] == x end),
+             Enum.sum(Map.values(preferred_locations_by_level[x].slots))
+           )}
+        end)
 
-    unhoused_citizens_split =
-      Map.new(5..0, fn x ->
-        {x,
-         Enum.split(
-           Enum.filter(unhoused_citizens, fn cit -> cit["education"] == x end),
-           Enum.sum(Map.values(unemployed_preferred_locations_by_level[x].slots))
-         )}
-      end)
-
-    unhoused_preferred_locations_by_level =
-      Map.new(5..0, fn level ->
-        {level,
-         Enum.reduce(
-           elem(unhoused_citizens_split[level], 0),
-           %{
-             choices: [],
-             slots: unemployed_preferred_locations_by_level[level].slots
-           },
-           fn citizen, acc ->
-             chosen_city =
-               Enum.reduce(
-                 acc.slots,
-                 %{
-                   chosen_id: citizen["town_id"],
-                   top_score: -1
-                 },
-                 fn {city_id, count}, acc2 ->
-                   score =
-                     if count > 0 && city_id != citizen["town_id"] do
-                       city_preference_scores[citizen["preferences"]][citizen["education"]][
-                         city_id
-                       ]
-                     else
-                       0
-                     end
-
-                   if score > acc2.top_score do
-                     %{
-                       chosen_id: city_id,
-                       top_score: score
-                     }
-                   else
-                     acc2
-                   end
-                 end
-               )
-
-             updated_slots =
-               acc.slots
-               |> Map.update(chosen_city.chosen_id, 0, &(&1 - 1))
-
+      unemployed_preferred_locations_by_level =
+        Map.new(5..0, fn level ->
+          {level,
+           Enum.reduce(
+             elem(unemployed_citizens_split[level], 0),
              %{
-               choices: [{citizen, chosen_city.chosen_id} | acc.choices],
-               slots: updated_slots
-             }
-           end
-         )}
-      end)
+               choices: [],
+               slots: preferred_locations_by_level[level].slots
+             },
+             fn citizen, acc ->
+               chosen_city =
+                 Enum.reduce(
+                   acc.slots,
+                   %{
+                     chosen_id: citizen["town_id"],
+                     top_score: -1
+                   },
+                   fn {city_id, count}, acc2 ->
+                     score =
+                       if count > 0 && city_id != citizen["town_id"] do
+                         city_preference_scores[citizen["preferences"]][citizen["education"]][
+                           city_id
+                         ]
+                       else
+                         0
+                       end
 
-    # find a way to return these to origin city
-    unhoused_split_2 =
-      Enum.reduce(unhoused_citizens_split, [], fn {_k, v}, acc ->
-        List.flatten([elem(v, 1) | acc])
-      end)
+                     if score > acc2.top_score do
+                       %{
+                         chosen_id: city_id,
+                         top_score: score
+                       }
+                     else
+                       acc2
+                     end
+                   end
+                 )
 
-    # ^ array of citizens who are still looking, that didn't make it into the level-specific comparisons
+               updated_slots =
+                 acc.slots
+                 |> Map.update(chosen_city.chosen_id, 0, &(&1 - 1))
 
-    # update the citizen's choice
-    updated_citizens_by_id_6 =
-      Enum.reduce(5..0, updated_citizens_by_id_5, fn x, acc ->
-        if unhoused_preferred_locations_by_level[x].choices != [] do
-          Enum.reduce(unhoused_preferred_locations_by_level[x].choices, acc, fn {citizen, chosen_city_id}, acc2 ->
+               %{
+                 choices: [{citizen, chosen_city.chosen_id} | acc.choices],
+                 slots: updated_slots
+               }
+             end
+           )}
+        end)
+
+      # find a way to return these to origin city
+      unemployed_split_2 =
+        Enum.reduce(unemployed_citizens_split, [], fn {_k, v}, acc ->
+          List.flatten([elem(v, 1) | acc])
+        end)
+
+      # update the citizen's choice
+      updated_citizens_by_id_4 =
+        Enum.reduce(5..0, updated_citizens_by_id_3, fn x, acc ->
+          # if unemployed_preferred_locations_by_level[x].choices != [] do
+          Enum.reduce(unemployed_preferred_locations_by_level[x].choices, acc, fn {citizen,
+                                                                                   chosen_city_id},
+                                                                                  acc2 ->
             if citizen["town_id"] != chosen_city_id do
               acc2
               |> Map.update!(
@@ -637,287 +543,443 @@ defmodule MayorGame.CityMigrator do
               )
             end
           end)
-        else
-          acc
-        end
-      end)
 
-    vacated_slots_3 =
-      Enum.flat_map(unhoused_preferred_locations_by_level, fn {_level, preferred_locations} ->
-        preferred_locations.choices
-        |> Enum.filter(fn {citizen, city_id} -> citizen["town_id"] != city_id end)
-        |> Enum.map(fn {citizen, _city_id} -> citizen["town_id"] end)
-      end)
+          # else
+          # acc
+          # end
+        end)
 
-    occupied_slots_3 =
-      Enum.flat_map(unhoused_preferred_locations_by_level, fn {_level, preferred_locations} ->
-        preferred_locations.choices
-        |> Enum.filter(fn {citizen, city_id} -> citizen["town_id"] != city_id end)
-        |> Enum.map(fn {_citizen, city_id} -> city_id end)
-      end)
-
-    vacated_freq_3 = Enum.frequencies(vacated_slots_3)
-    occupied_freq_3 = Enum.frequencies(occupied_slots_3)
-
-    housing_slots_4 =
-      housing_slots_3
-      |> Map.merge(vacated_freq_3, fn _k, v1, v2 -> v1 + v2 end)
-      |> Map.merge(occupied_freq_3, fn _k, v1, v2 -> v1 - v2 end)
-
-    # shape: [city_id, city_id, city_id]
-    # subtract these from housing_slots
-    # ok this is an array of… I think… housing to remove from those cities
-    # this means a job was taken from second elem, and giving housing to the first one
-    # yes
-    # adjust housing_slots here
-
-    # have to subtract from housing_slots and run again
-
-    # ok gotta make an updated slots thingy
-
-    # ——————————————————————————————————————————————————————————————————————————————————
-    # ————————————————————————————————————————— ROUND 1.5: MOVE UNEMPLOYED CITIZENS
-    # ——————————————————————————————————————————————————————————————————————————————————
-
-    # ——————————————————————————————————————————————————————————————————————————————————
-    # ————————————————————————————————————————— ROUND 2: MOVE CITIZENS ANYWHERE THERE IS HOUSING
-    # ——————————————————————————————————————————————————————————————————————————————————
-
-    slots_after_job_filtered = Enum.filter(housing_slots_4, fn {_k, v} -> v > 0 end) |> Enum.into(%{})
-
-    housing_slots_left = Enum.sum(Map.values(housing_slots_4))
-
-    unhoused_split_3 = unhoused_split_2 |> Enum.split(housing_slots_left)
-
-    # SHAPE OF unhoused_locations.choices is an array of {citizen, city_id}
-    unhoused_preferred_locations =
-      Enum.reduce(
-        elem(unhoused_split_3, 0),
-        %{choices: [], slots: slots_after_job_filtered},
-        fn citizen, acc ->
-          current_city_score =
-            city_preference_scores[citizen["preferences"]][citizen["education"]][
-              citizen["town_id"]
-            ]
-
-          chosen_city =
-            Enum.reduce(
-              acc.slots,
-              %{chosen_id: citizen["town_id"], top_score: current_city_score},
-              fn {city_id, count}, acc2 ->
-                score =
-                  if count > 0 do
-                    city_preference_scores[citizen["preferences"]][citizen["education"]][city_id]
-                  else
-                    0
-                  end
-
-                if score > acc2.top_score && score do
-                  %{
-                    chosen_id: city_id,
-                    top_score: score
-                  }
-                else
-                  acc2
-                end
-              end
+      # add non-lookers back
+      updated_citizens_by_id_5 =
+        if unemployed_split_2 != [] do
+          Enum.reduce(unemployed_split_2, updated_citizens_by_id_4, fn citizen, acc ->
+            acc
+            |> Map.update!(
+              citizen["town_id"],
+              &[
+                citizen |> Map.take(["education", "preferences", "last_moved", "age"]) | &1
+              ]
             )
-
-          updated_slots =
-            acc.slots
-            |> Map.update(chosen_city.chosen_id, 0, &(&1 - 1))
-            |> Map.update(citizen["town_id"], 0, &(&1 + 1))
-
-          %{
-            choices:
-              if chosen_city.chosen_id == 0 do
-                acc.choices
-              else
-                [{citizen, chosen_city.chosen_id} | acc.choices]
-              end,
-            slots: updated_slots
-          }
-        end
-      )
-
-    updated_citizens_by_id_7 =
-      Enum.reduce(unhoused_preferred_locations.choices, updated_citizens_by_id_6, fn {citizen, chosen_city_id}, acc ->
-        if citizen["town_id"] != chosen_city_id do
-          acc |> Map.update!(chosen_city_id, &[citizen | &1])
+          end)
         else
-          acc
+          updated_citizens_by_id_4
         end
-      end)
 
-    unhoused_deaths = elem(unhoused_split_3, 1) |> Enum.frequencies_by(& &1["town_id"])
-    # ok cool
-    # logs_deaths_housing: integer,
+      vacated_slots_2 =
+        Enum.flat_map(unemployed_preferred_locations_by_level, fn {_level, preferred_locations} ->
+          preferred_locations.choices
+          |> Enum.filter(fn {citizen, city_id} -> citizen["town_id"] != city_id end)
+          |> Enum.map(fn {citizen, _city_id} -> citizen["town_id"] end)
+        end)
 
-    # :logs_emigration_taxes,
-    for_tax_logs =
-      Enum.flat_map(preferred_locations_by_level, fn {_key, val} ->
-        Enum.filter(val.choices, fn {citizen, chosen_id} -> citizen["town_id"] != chosen_id end)
-      end)
+      occupied_slots_2 =
+        Enum.flat_map(unemployed_preferred_locations_by_level, fn {_level, preferred_locations} ->
+          preferred_locations.choices
+          |> Enum.filter(fn {citizen, city_id} -> citizen["town_id"] != city_id end)
+          |> Enum.map(fn {_citizen, city_id} -> city_id end)
+        end)
 
-    tax_cities_chosen = Enum.group_by(for_tax_logs, &elem(&1, 1))
-    tax_cities_left = Enum.group_by(for_tax_logs, &elem(&1, 0)["town_id"])
+      vacated_freq_2 = Enum.frequencies(vacated_slots_2)
+      occupied_freq_2 = Enum.frequencies(occupied_slots_2)
 
-    tax_cities_left_by_edu =
-      Enum.map(tax_cities_left, fn {city_id, array} ->
-        {city_id, Enum.frequencies_by(array, &elem(&1, 0)["education"])}
-      end)
-      |> Map.new()
+      housing_slots_3 =
+        housing_slots_2
+        |> Map.merge(vacated_freq_2, fn _k, v1, v2 -> v1 + v2 end)
+        |> Map.merge(occupied_freq_2, fn _k, v1, v2 -> v1 - v2 end)
 
-    # :logs_emigration_jobs,
-    for_jobs_logs =
-      Enum.flat_map(unemployed_preferred_locations_by_level, fn {_key, val} ->
-        Enum.filter(val.choices, fn {citizen, chosen_id} -> citizen["town_id"] != chosen_id end)
-      end)
+      # NEW UNHOUSED CODE —————————————————————————————————————————————————————————————
+      # ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      # ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      # ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      # ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      # ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
 
-    job_cities_chosen = Enum.group_by(for_jobs_logs, &elem(&1, 1))
-    job_cities_left = Enum.group_by(for_jobs_logs, &elem(&1, 0)["town_id"])
+      unhoused_citizens_split =
+        Map.new(5..0, fn x ->
+          {x,
+           Enum.split(
+             Enum.filter(unhoused_citizens, fn cit -> cit["education"] == x end),
+             Enum.sum(Map.values(unemployed_preferred_locations_by_level[x].slots))
+           )}
+        end)
 
-    job_cities_left_by_edu =
-      Enum.map(job_cities_left, fn {city_id, array} ->
-        {city_id, Enum.frequencies_by(array, &elem(&1, 0)["education"])}
-      end)
-      |> Map.new()
+      unhoused_preferred_locations_by_level =
+        Map.new(5..0, fn level ->
+          {level,
+           Enum.reduce(
+             elem(unhoused_citizens_split[level], 0),
+             %{
+               choices: [],
+               slots: unemployed_preferred_locations_by_level[level].slots
+             },
+             fn citizen, acc ->
+               chosen_city =
+                 Enum.reduce(
+                   acc.slots,
+                   %{
+                     chosen_id: citizen["town_id"],
+                     top_score: -1
+                   },
+                   fn {city_id, count}, acc2 ->
+                     score =
+                       if count > 0 && city_id != citizen["town_id"] do
+                         city_preference_scores[citizen["preferences"]][citizen["education"]][
+                           city_id
+                         ]
+                       else
+                         0
+                       end
 
-    # :logs_emigration_housing,
-    for_unhoused_logs =
-      Enum.flat_map(unhoused_preferred_locations_by_level, fn {_key, val} ->
-        Enum.filter(val.choices, fn {citizen, chosen_id} -> citizen["town_id"] != chosen_id end)
-      end)
+                     if score > acc2.top_score do
+                       %{
+                         chosen_id: city_id,
+                         top_score: score
+                       }
+                     else
+                       acc2
+                     end
+                   end
+                 )
 
-    for_unhoused_logs_2 =
-      Enum.filter(unhoused_preferred_locations.choices, fn {citizen, chosen_id} ->
-        citizen["town_id"] != chosen_id
-      end)
+               updated_slots =
+                 acc.slots
+                 |> Map.update(chosen_city.chosen_id, 0, &(&1 - 1))
 
-    housing_cities_chosen = Enum.group_by(for_unhoused_logs, &elem(&1, 1))
-    housing_cities_left = Enum.group_by(for_unhoused_logs, &elem(&1, 0)["town_id"])
-    housing_cities_left_2 = Enum.group_by(for_unhoused_logs_2, &elem(&1, 0)["town_id"])
+               %{
+                 choices: [{citizen, chosen_city.chosen_id} | acc.choices],
+                 slots: updated_slots
+               }
+             end
+           )}
+        end)
 
-    merged_housing_cities_left = Map.merge(housing_cities_left, housing_cities_left_2, fn _k, v1, v2 -> v1 ++ v2 end)
+      # find a way to return these to origin city
+      unhoused_split_2 =
+        Enum.reduce(unhoused_citizens_split, [], fn {_k, v}, acc ->
+          List.flatten([elem(v, 1) | acc])
+        end)
 
-    housing_cities_left_by_edu =
-      Enum.map(merged_housing_cities_left, fn {city_id, array} ->
-        {city_id, Enum.frequencies_by(array, &elem(&1, 0)["education"])}
-      end)
-      |> Map.new()
+      # ^ array of citizens who are still looking, that didn't make it into the level-specific comparisons
 
-    # filter updated_citizens to remove jas_job and town_id before going in the DB
-
-    updated_citizens_by_id_7
-    |> Enum.chunk_every(200)
-    |> Enum.each(fn chunk ->
-      Repo.checkout(
-        # each comes with a city_id and a list of citizens
-        fn ->
-          Enum.each(chunk, fn {id, list} ->
-            # each ID
-            logs_emigration_taxes =
-              if !is_nil(tax_cities_left_by_edu[id]) do
-                Map.merge(
-                  CityHelpers.integerize_keys(slotted_cities_by_id[id].city.logs_emigration_taxes),
-                  tax_cities_left_by_edu[id],
-                  fn _k, v1, v2 -> v1 + v2 end
+      # update the citizen's choice
+      updated_citizens_by_id_6 =
+        Enum.reduce(5..0, updated_citizens_by_id_5, fn x, acc ->
+          if unhoused_preferred_locations_by_level[x].choices != [] do
+            Enum.reduce(unhoused_preferred_locations_by_level[x].choices, acc, fn {citizen,
+                                                                                   chosen_city_id},
+                                                                                  acc2 ->
+              if citizen["town_id"] != chosen_city_id do
+                acc2
+                |> Map.update!(
+                  chosen_city_id,
+                  &[
+                    citizen
+                    |> Map.take(["education", "preferences", "last_moved", "age"])
+                    |> Map.put("last_moved", db_world.day)
+                    | &1
+                  ]
                 )
               else
-                slotted_cities_by_id[id].city.logs_emigration_taxes
-              end
-
-            logs_emigration_jobs =
-              if !is_nil(job_cities_left_by_edu[id]) do
-                Map.merge(
-                  CityHelpers.integerize_keys(slotted_cities_by_id[id].city.logs_emigration_jobs),
-                  job_cities_left_by_edu[id],
-                  fn _k, v1, v2 -> v1 + v2 end
+                acc2
+                |> Map.update!(
+                  chosen_city_id,
+                  &[citizen |> Map.take(["education", "preferences", "last_moved", "age"]) | &1]
                 )
-              else
-                slotted_cities_by_id[id].city.logs_emigration_jobs
               end
+            end)
+          else
+            acc
+          end
+        end)
 
-            logs_emigration_housing =
-              if !is_nil(housing_cities_left_by_edu[id]) do
-                Map.merge(
-                  CityHelpers.integerize_keys(slotted_cities_by_id[id].city.logs_emigration_housing),
-                  housing_cities_left_by_edu[id],
-                  fn _k, v1, v2 -> v1 + v2 end
-                )
-              else
-                slotted_cities_by_id[id].city.logs_emigration_housing
-              end
+      vacated_slots_3 =
+        Enum.flat_map(unhoused_preferred_locations_by_level, fn {_level, preferred_locations} ->
+          preferred_locations.choices
+          |> Enum.filter(fn {citizen, city_id} -> citizen["town_id"] != city_id end)
+          |> Enum.map(fn {citizen, _city_id} -> citizen["town_id"] end)
+        end)
 
-            updated_edu_logs =
-              Map.merge(
-                CityHelpers.integerize_keys(slotted_cities_by_id[id].city.logs_edu),
-                slotted_cities_by_id[id].city.educated_citizens,
-                fn _k, v1, v2 ->
-                  v1 + v2
+      occupied_slots_3 =
+        Enum.flat_map(unhoused_preferred_locations_by_level, fn {_level, preferred_locations} ->
+          preferred_locations.choices
+          |> Enum.filter(fn {citizen, city_id} -> citizen["town_id"] != city_id end)
+          |> Enum.map(fn {_citizen, city_id} -> city_id end)
+        end)
+
+      vacated_freq_3 = Enum.frequencies(vacated_slots_3)
+      occupied_freq_3 = Enum.frequencies(occupied_slots_3)
+
+      housing_slots_4 =
+        housing_slots_3
+        |> Map.merge(vacated_freq_3, fn _k, v1, v2 -> v1 + v2 end)
+        |> Map.merge(occupied_freq_3, fn _k, v1, v2 -> v1 - v2 end)
+
+      # shape: [city_id, city_id, city_id]
+      # subtract these from housing_slots
+      # ok this is an array of… I think… housing to remove from those cities
+      # this means a job was taken from second elem, and giving housing to the first one
+      # yes
+      # adjust housing_slots here
+
+      # have to subtract from housing_slots and run again
+
+      # ok gotta make an updated slots thingy
+
+      # ——————————————————————————————————————————————————————————————————————————————————
+      # ————————————————————————————————————————— ROUND 1.5: MOVE UNEMPLOYED CITIZENS
+      # ——————————————————————————————————————————————————————————————————————————————————
+
+      # ——————————————————————————————————————————————————————————————————————————————————
+      # ————————————————————————————————————————— ROUND 2: MOVE CITIZENS ANYWHERE THERE IS HOUSING
+      # ——————————————————————————————————————————————————————————————————————————————————
+
+      slots_after_job_filtered =
+        Enum.filter(housing_slots_4, fn {_k, v} -> v > 0 end) |> Enum.into(%{})
+
+      housing_slots_left = Enum.sum(Map.values(housing_slots_4))
+
+      unhoused_split_3 = unhoused_split_2 |> Enum.split(housing_slots_left)
+
+      # SHAPE OF unhoused_locations.choices is an array of {citizen, city_id}
+      unhoused_preferred_locations =
+        Enum.reduce(
+          elem(unhoused_split_3, 0),
+          %{choices: [], slots: slots_after_job_filtered},
+          fn citizen, acc ->
+            current_city_score =
+              city_preference_scores[citizen["preferences"]][citizen["education"]][
+                citizen["town_id"]
+              ]
+
+            chosen_city =
+              Enum.reduce(
+                acc.slots,
+                %{chosen_id: citizen["town_id"], top_score: current_city_score},
+                fn {city_id, count}, acc2 ->
+                  score =
+                    if count > 0 do
+                      city_preference_scores[citizen["preferences"]][citizen["education"]][
+                        city_id
+                      ]
+                    else
+                      0
+                    end
+
+                  if score > acc2.top_score && score do
+                    %{
+                      chosen_id: city_id,
+                      top_score: score
+                    }
+                  else
+                    acc2
+                  end
                 end
               )
 
-            births_count =
-              if slotted_cities_by_id[id].city.citizen_count > 100 do
-                slotted_cities_by_id[id].city.reproducing_citizens
-              else
-                if :rand.uniform() > 0.8 do
-                  1
+            updated_slots =
+              acc.slots
+              |> Map.update(chosen_city.chosen_id, 0, &(&1 - 1))
+              |> Map.update(citizen["town_id"], 0, &(&1 + 1))
+
+            %{
+              choices:
+                if chosen_city.chosen_id == 0 do
+                  acc.choices
                 else
-                  0
+                  [{citizen, chosen_city.chosen_id} | acc.choices]
+                end,
+              slots: updated_slots
+            }
+          end
+        )
+
+      updated_citizens_by_id_7 =
+        Enum.reduce(unhoused_preferred_locations.choices, updated_citizens_by_id_6, fn {citizen,
+                                                                                        chosen_city_id},
+                                                                                       acc ->
+          if citizen["town_id"] != chosen_city_id do
+            acc |> Map.update!(chosen_city_id, &[citizen | &1])
+          else
+            acc
+          end
+        end)
+
+      unhoused_deaths = elem(unhoused_split_3, 1) |> Enum.frequencies_by(& &1["town_id"])
+      # ok cool
+      # logs_deaths_housing: integer,
+
+      # :logs_emigration_taxes,
+      for_tax_logs =
+        Enum.flat_map(preferred_locations_by_level, fn {_key, val} ->
+          Enum.filter(val.choices, fn {citizen, chosen_id} -> citizen["town_id"] != chosen_id end)
+        end)
+
+      # tax_cities_chosen = Enum.group_by(for_tax_logs, &elem(&1, 1))
+      tax_cities_left = Enum.group_by(for_tax_logs, &elem(&1, 0)["town_id"])
+
+      tax_cities_left_by_edu =
+        Enum.map(tax_cities_left, fn {city_id, array} ->
+          {city_id, Enum.frequencies_by(array, &elem(&1, 0)["education"])}
+        end)
+        |> Map.new()
+
+      # :logs_emigration_jobs,
+      for_jobs_logs =
+        Enum.flat_map(unemployed_preferred_locations_by_level, fn {_key, val} ->
+          Enum.filter(val.choices, fn {citizen, chosen_id} -> citizen["town_id"] != chosen_id end)
+        end)
+
+      # job_cities_chosen = Enum.group_by(for_jobs_logs, &elem(&1, 1))
+      job_cities_left = Enum.group_by(for_jobs_logs, &elem(&1, 0)["town_id"])
+
+      job_cities_left_by_edu =
+        Enum.map(job_cities_left, fn {city_id, array} ->
+          {city_id, Enum.frequencies_by(array, &elem(&1, 0)["education"])}
+        end)
+        |> Map.new()
+
+      # :logs_emigration_housing,
+      for_unhoused_logs =
+        Enum.flat_map(unhoused_preferred_locations_by_level, fn {_key, val} ->
+          Enum.filter(val.choices, fn {citizen, chosen_id} -> citizen["town_id"] != chosen_id end)
+        end)
+
+      for_unhoused_logs_2 =
+        Enum.filter(unhoused_preferred_locations.choices, fn {citizen, chosen_id} ->
+          citizen["town_id"] != chosen_id
+        end)
+
+      # housing_cities_chosen = Enum.group_by(for_unhoused_logs, &elem(&1, 1))
+      housing_cities_left = Enum.group_by(for_unhoused_logs, &elem(&1, 0)["town_id"])
+      housing_cities_left_2 = Enum.group_by(for_unhoused_logs_2, &elem(&1, 0)["town_id"])
+
+      merged_housing_cities_left =
+        Map.merge(housing_cities_left, housing_cities_left_2, fn _k, v1, v2 -> v1 ++ v2 end)
+
+      housing_cities_left_by_edu =
+        Enum.map(merged_housing_cities_left, fn {city_id, array} ->
+          {city_id, Enum.frequencies_by(array, &elem(&1, 0)["education"])}
+        end)
+        |> Map.new()
+
+      # filter updated_citizens to remove jas_job and town_id before going in the DB
+
+      updated_citizens_by_id_7
+      |> Enum.chunk_every(200)
+      |> Enum.each(fn chunk ->
+        Repo.checkout(
+          # each comes with a city_id and a list of citizens
+          fn ->
+            Enum.each(chunk, fn {id, list} ->
+              # each ID
+              logs_emigration_taxes =
+                if !is_nil(tax_cities_left_by_edu[id]) do
+                  Map.merge(
+                    CityHelpers.integerize_keys(
+                      slotted_cities_by_id[id].city.logs_emigration_taxes
+                    ),
+                    tax_cities_left_by_edu[id],
+                    fn _k, v1, v2 -> v1 + v2 end
+                  )
+                else
+                  slotted_cities_by_id[id].city.logs_emigration_taxes
                 end
-              end
 
-            updated_citizens =
-              if births_count > 0 do
-                Enum.map(1..births_count, fn _citizen ->
-                  %{
-                    "age" => 0,
-                    "town_id" => id,
-                    "education" => 0,
-                    "last_moved" => db_world.day,
-                    "has_job" => false,
-                    "preferences" => :rand.uniform(10)
-                  }
-                end) ++ list
-              else
-                list
-              end
+              logs_emigration_jobs =
+                if !is_nil(job_cities_left_by_edu[id]) do
+                  Map.merge(
+                    CityHelpers.integerize_keys(
+                      slotted_cities_by_id[id].city.logs_emigration_jobs
+                    ),
+                    job_cities_left_by_edu[id],
+                    fn _k, v1, v2 -> v1 + v2 end
+                  )
+                else
+                  slotted_cities_by_id[id].city.logs_emigration_jobs
+                end
 
-            # ok wtf. even this looks right
+              logs_emigration_housing =
+                if !is_nil(housing_cities_left_by_edu[id]) do
+                  Map.merge(
+                    CityHelpers.integerize_keys(
+                      slotted_cities_by_id[id].city.logs_emigration_housing
+                    ),
+                    housing_cities_left_by_edu[id],
+                    fn _k, v1, v2 -> v1 + v2 end
+                  )
+                else
+                  slotted_cities_by_id[id].city.logs_emigration_housing
+                end
 
-            unhoused_deaths = if Map.has_key?(unhoused_deaths, id), do: unhoused_deaths[id], else: 0
+              updated_edu_logs =
+                Map.merge(
+                  CityHelpers.integerize_keys(slotted_cities_by_id[id].city.logs_edu),
+                  slotted_cities_by_id[id].city.educated_citizens,
+                  fn _k, v1, v2 ->
+                    v1 + v2
+                  end
+                )
 
-            from(t in Town,
-              where: t.id == ^id,
-              update: [
-                set: [
-                  logs_emigration_taxes: ^logs_emigration_taxes,
-                  logs_emigration_jobs: ^logs_emigration_jobs,
-                  logs_emigration_housing: ^logs_emigration_housing,
-                  logs_edu: ^updated_edu_logs,
-                  citizen_count: ^length(updated_citizens),
-                  citizens_blob: ^updated_citizens
-                ],
-                inc: [
-                  logs_deaths_housing: ^unhoused_deaths,
-                  logs_deaths_pollution: ^length(slotted_cities_by_id[id].city.polluted_citizens),
-                  logs_deaths_age: ^length(slotted_cities_by_id[id].city.old_citizens),
-                  logs_births: ^births_count
+              births_count =
+                if slotted_cities_by_id[id].city.citizen_count > 100 do
+                  slotted_cities_by_id[id].city.aggregate_births
+                else
+                  if :rand.uniform() > 0.8 do
+                    1
+                  else
+                    0
+                  end
+                end
+
+              updated_citizens =
+                if births_count > 0 do
+                  Enum.map(1..births_count, fn _citizen ->
+                    %{
+                      "age" => 0,
+                      "town_id" => id,
+                      "education" => 0,
+                      "last_moved" => db_world.day,
+                      "preferences" => :rand.uniform(10)
+                    }
+                  end) ++ list
+                else
+                  list
+                end
+
+              # ok wtf. even this looks right
+
+              unhoused_deaths =
+                if Map.has_key?(unhoused_deaths, id), do: unhoused_deaths[id], else: 0
+
+              from(t in Town,
+                where: t.id == ^id,
+                update: [
+                  set: [
+                    logs_emigration_taxes: ^logs_emigration_taxes,
+                    logs_emigration_jobs: ^logs_emigration_jobs,
+                    logs_emigration_housing: ^logs_emigration_housing,
+                    logs_edu: ^updated_edu_logs,
+                    citizen_count: ^length(updated_citizens),
+                    citizens_blob: ^updated_citizens
+                  ],
+                  inc: [
+                    logs_deaths_housing: ^unhoused_deaths,
+                    logs_deaths_pollution:
+                      ^length(slotted_cities_by_id[id].city.polluted_citizens),
+                    logs_deaths_age: ^slotted_cities_by_id[id].city.aggregate_deaths_by_age,
+                    logs_births: ^births_count
+                  ]
                 ]
-              ]
-            )
-            |> Repo.update_all([])
+              )
+              |> Repo.update_all([])
 
-            # ok wtf even this seems to work
-          end)
-        end,
-        timeout: 6_000_000
-      )
-    end)
-
-    IO.puts("MOVED————————————————————————————————————————————")
+              # ok wtf even this seems to work
+            end)
+          end,
+          timeout: 6_000_000
+        )
+      end)
+    end
 
     # SEND RESULTS TO CLIENTS
     # send val to liveView process that manages front-end; this basically sends to every client.
@@ -925,6 +987,15 @@ defmodule MayorGame.CityMigrator do
       "cityPubSub",
       "pong",
       db_world
+    )
+
+    # profiling
+    {:ok, datetime_post} = DateTime.now("Etc/UTC")
+
+    IO.puts(
+      (datetime_post |> DateTime.to_string()) <>
+        " | Migration Tick | Time: " <>
+        to_string(DateTime.diff(datetime_post, datetime_pre, :millisecond)) <> " ms"
     )
 
     # recurse, do it again
@@ -940,18 +1011,6 @@ defmodule MayorGame.CityMigrator do
      }}
   end
 
-  def update_logs(log, existing_logs) do
-    updated_log = if !is_nil(existing_logs), do: [log | existing_logs], else: [log]
-
-    # updated_log = [log | existing_logs]
-
-    if length(updated_log) > 50 do
-      updated_log |> Enum.take(50)
-    else
-      updated_log
-    end
-  end
-
   def nil_value_check(map, key) do
     if Map.has_key?(map, key), do: map[key], else: 0
   end
@@ -959,12 +1018,28 @@ defmodule MayorGame.CityMigrator do
   def normalize_city(city, max_fun, spread_health, spread_pollution, max_sprawl) do
     %{
       city: city,
-      jobs: city.jobs,
+      jobs: city.vacancies_by_level,
       id: city.id,
-      sprawl_normalized: zero_check(nil_value_check(city, :sprawl), max_sprawl),
-      pollution_normalized: zero_check(nil_value_check(city, :pollution), spread_pollution),
-      fun_normalized: zero_check(nil_value_check(city, :fun), max_fun),
-      health_normalized: zero_check(nil_value_check(city, :health), spread_health),
+      sprawl_normalized:
+        zero_check(
+          city |> TownStatistics.getResource(:sprawl) |> ResourceStatistics.getNetProduction(),
+          max_sprawl
+        ),
+      pollution_normalized:
+        zero_check(
+          city |> TownStatistics.getResource(:pollution) |> ResourceStatistics.getNetProduction(),
+          spread_pollution
+        ),
+      fun_normalized:
+        zero_check(
+          city |> TownStatistics.getResource(:fun) |> ResourceStatistics.getNetProduction(),
+          max_fun
+        ),
+      health_normalized:
+        zero_check(
+          city |> TownStatistics.getResource(:health) |> ResourceStatistics.getNetProduction(),
+          spread_health
+        ),
       tax_rates: city.tax_rates
     }
   end

--- a/lib/mayor_game/city_calculator/rules.ex
+++ b/lib/mayor_game/city_calculator/rules.ex
@@ -1,0 +1,43 @@
+defmodule MayorGame.Rules do
+  alias MayorGame.City.{World}
+
+  @spec building_price(integer, integer) :: integer
+  def building_price(initial_price, buildable_count) do
+    initial_price * round(:math.pow(buildable_count, 2) + 1)
+  end
+
+  @spec calculate_earnings(integer, integer, number) :: integer
+  def calculate_earnings(worker_count, level, tax_rate) do
+    round(worker_count * :math.pow(2, level) * 100 * (tax_rate / 10))
+  end
+
+  @spec is_citizen_reproductive(map) :: boolean
+  def is_citizen_reproductive(citizen) do
+    citizen["age"] > 15 && citizen["age"] < 4000
+  end
+
+  @spec is_citizen_within_lifespan(map) :: boolean
+  def is_citizen_within_lifespan(citizen) do
+    citizen["age"] < 3000 * (citizen["education"] + 1)
+  end
+
+  @spec is_citizen_restless(map, %World{}) :: boolean
+  def is_citizen_restless(citizen, world) do
+    citizen["last_moved"] < world.day - 10 * citizen["education"]
+  end
+
+  @spec excessive_tax_chance(integer, number) :: number
+  def excessive_tax_chance(level, tax_rate) do
+    :math.pow(tax_rate, 7 - level)
+  end
+
+  @spec season_from_day(integer) :: atom
+  def season_from_day(day) do
+    cond do
+      rem(day, 365) < 91 -> :winter
+      rem(day, 365) < 182 -> :spring
+      rem(day, 365) < 273 -> :summer
+      true -> :fall
+    end
+  end
+end

--- a/lib/mayor_game/city_calculator/utility.ex
+++ b/lib/mayor_game/city_calculator/utility.ex
@@ -1,0 +1,13 @@
+defmodule MayorGame.Utility do
+
+  @spec dice_roll(integer, number) :: integer
+  def dice_roll(number_of_trials, probability) do
+    # issue with Statistics.Distributions.Binomial as of statistics 0.6.2, raised in https://github.com/msharp/elixir-statistics/issues/30
+    # for now, add a guard
+    cond do
+      number_of_trials == 0 -> 0
+      number_of_trials == 1 -> :rand.uniform() < probability
+      number_of_trials > 1 -> round(Statistics.Distributions.Binomial.rand(number_of_trials, probability))
+    end
+  end
+end

--- a/lib/mayor_game_web/templates/city/show.html.heex
+++ b/lib/mayor_game_web/templates/city/show.html.heex
@@ -51,7 +51,7 @@
         <span class="first-letter:uppercase"><%= @season %></span>
       </td>
       <td class="top_td">
-        <%= @total_citizens %>
+        <%= @city_stats.total_citizens %>
       </td>
     </tr>
   </table>
@@ -203,132 +203,92 @@
     <tr>
       <td class="top_td">
         <span class="text-purple-800">
-          <%= Number.SI.number_to_si(
-            @city.pollution,
-            precision: 3,
-            trim: true
-          ) %>/day
+          <%= @city_stats |> MayorGame.City.TownStatistics.getResource(:pollution) |> MayorGame.City.ResourceStatistics.expressNetProduction_SI()
+           %>/day
         </span>
       </td>
 
       <td class="top_td">
         <span class="text-amber-800">
-          <%= @city.housing - @total_citizens %>/<%= Number.SI.number_to_si(
-            @city.housing,
-            precision: 3,
-            trim: true
-          ) %>
+          <%= @city_stats |> MayorGame.City.TownStatistics.getResource(:housing) |> MayorGame.City.ResourceStatistics.expressAvailableOverSupply_SI()
+           %>
         </span>
       </td>
       <td class="top_td">
         <span class="text-green-800">
-          <%= Enum.sum(Map.values(@city.jobs)) %>/<%= Enum.sum(Map.values(@city.total_jobs)) %>
+          <%= Enum.sum(Map.values(@city_stats.jobs_by_level)) - Enum.sum(Map.values(@city_stats.employed_citizen_count_by_level)) %>/<%= Enum.sum(Map.values(@city_stats.jobs_by_level)) %>
         </span>
       </td>
       <td class="top_td">
         <span class="text-green-800">
-          $<%= Number.SI.number_to_si(
-            @city.income,
-            precision: 3,
-            trim: true
-          ) %>/day
+          $<%= @city_stats |> MayorGame.City.TownStatistics.getResource(:money) |> MayorGame.City.ResourceStatistics.expressProduction_SI()
+           %>/day
         </span>
       </td>
       <td class="top_td">
         <span class="text-red-800">
-          $<%= Number.SI.number_to_si(
-            @city.daily_cost,
-            precision: 3,
-            trim: true
-          ) %>/day
+          $<%= @city_stats |> MayorGame.City.TownStatistics.getResource(:money) |> MayorGame.City.ResourceStatistics.expressConsumption_SI()
+           %>/day
         </span>
       </td>
       <td class="top_td">
         <span class="text-green-800">
-          $<%= Number.SI.number_to_si(
-            @city.treasury,
-            precision: 3,
-            trim: true
-          ) %>
+          $<%= @city_stats |> MayorGame.City.TownStatistics.getResource(:money) |> MayorGame.City.ResourceStatistics.expressStock_SI(-@construction_cost)
+           %>
         </span>
       </td>
       <td class="top_td">
         <span class="text-yellow-800">
-          <%= Number.SI.number_to_si(
-            @city.energy,
-            precision: 3,
-            trim: true
-          ) %>/<%= Number.SI.number_to_si(
-            @city.total_energy,
-            precision: 3,
-            trim: true
-          ) %>
+          <%= @city_stats |> MayorGame.City.TownStatistics.getResource(:energy) |> MayorGame.City.ResourceStatistics.expressAvailableOverSupply_SI()
+           %>
         </span>
       </td>
       <td class="top_td">
         <span class="text-cyan-800">
-          <%= Number.SI.number_to_si(
-            @city.area,
-            precision: 3,
-            trim: true
-          ) %>/<%= Number.SI.number_to_si(
-            @city.total_area,
-            precision: 3,
-            trim: true
-          ) %>
+          <%= @city_stats |> MayorGame.City.TownStatistics.getResource(:area) |> MayorGame.City.ResourceStatistics.expressAvailableOverSupply_SI()
+           %>
         </span>
       </td>
-      <td class="group relative h-4 top_td text-fuchsia-800">
-        <%= Number.Delimit.number_to_delimited(@city.fun) %>
+      <td class="top_td">
+        <span class="text-fuchsia-800">
+          <%= @city_stats |> MayorGame.City.TownStatistics.getResource(:fun) |> MayorGame.City.ResourceStatistics.expressNetProduction_SI()
+           %>
+        </span>
       </td>
       <td class="top_td">
         <span class="text-rose-800">
-          <%= Number.Delimit.number_to_delimited(@city.health) %>
+          <%= @city_stats |> MayorGame.City.TownStatistics.getResource(:health) |> MayorGame.City.ResourceStatistics.expressNetProduction_SI()
+           %>
         </span>
       </td>
       <td class="top_td">
         <span class="text-slate-800">
-          <%= Number.SI.number_to_si(
-            @city.steel,
-            precision: 3,
-            trim: true
-          ) %>
+          <%= @city_stats |> MayorGame.City.TownStatistics.getResource(:steel) |> MayorGame.City.ResourceStatistics.expressStock_SI()
+           %>
         </span>
       </td>
       <td class="top_td">
         <span class="text-orange-800">
-          <%= Number.SI.number_to_si(
-            @city.sulfur,
-            precision: 3,
-            trim: true
-          ) %>
+          <%= @city_stats |> MayorGame.City.TownStatistics.getResource(:sulfur) |> MayorGame.City.ResourceStatistics.expressStock_SI()
+           %>
         </span>
       </td>
       <td class="top_td">
         <span class="text-purple-800">
-          <%= Number.SI.number_to_si(
-            @city.uranium,
-            precision: 3,
-            trim: true
-          ) %>
+          <%= @city_stats |> MayorGame.City.TownStatistics.getResource(:uranium) |> MayorGame.City.ResourceStatistics.expressStock_SI()
+           %>
         </span>
       </td>
       <td class="top_td">
         <span class="text-red-800">
-          <%= Number.SI.number_to_si(
-            @city.missiles,
-            precision: 3,
-            trim: true
-          ) %>/<%= max(@city.missiles_capacity, 50) %>
+          <%= @city_stats |> MayorGame.City.TownStatistics.getResource(:missiles) |> MayorGame.City.ResourceStatistics.expressStockOverStorage_SI()
+           %>
         </span>
       </td>
       <td class="top_td">
         <span class="text-blue-800">
-          <%= Number.SI.number_to_si(
-            @city.shields,
-            precision: 3,
-            trim: true
-          ) %>/<%= max(@city.shields_capacity, 50) %>
+          <%= @city_stats |> MayorGame.City.TownStatistics.getResource(:shields) |> MayorGame.City.ResourceStatistics.expressStockOverStorage_SI()
+           %>
         </span>
       </td>
     </tr>
@@ -386,8 +346,8 @@
           <% end %>
           <!--print citizen count at level-->
           <div>
-            <%= if @citizens_by_edu[String.to_integer(job_level)] !== nil do %>
-              <%= @citizens_by_edu[String.to_integer(job_level)] %>
+            <%= if @city_stats.citizen_count_by_level[String.to_integer(job_level)] !== nil do %>
+              <%= @city_stats.citizen_count_by_level[String.to_integer(job_level)] %>
             <% else %>
               0
             <% end %>
@@ -395,16 +355,16 @@
           </div>
           <!--print job count at level-->
           <div>
-            <%= if @city.total_jobs[String.to_integer(job_level)] !== nil do %>
-              <%= to_string(@city.total_jobs[String.to_integer(job_level)]) %>
+            <%= if @city_stats.jobs_by_level[String.to_integer(job_level)] !== nil do %>
+              <%= to_string(@city_stats.jobs_by_level[String.to_integer(job_level)]) %>
             <% else %>
               0
             <% end %>
             total jobs
           </div>
           <div>
-            <%= if @city.jobs[String.to_integer(job_level)] !== nil do %>
-              <%= to_string(@city.jobs[String.to_integer(job_level)]) %>
+            <%= if @city_stats.vacancies_by_level[String.to_integer(job_level)] !== nil do %>
+              <%= to_string(@city_stats.vacancies_by_level[String.to_integer(job_level)]) %>
             <% else %>
               0
             <% end %>
@@ -451,7 +411,7 @@
         Combat
       </h2>
       <div class="pb-4 flex flex-row items-center gap-2">
-        <%= if @city.shields > 0 && @current_user.town.missiles > 0 do %>
+        <%= if @city_stats |> MayorGame.City.TownStatistics.getResource(:shields) |> MayorGame.City.ResourceStatistics.getStock() > 0 && @current_user.town.missiles > 0 do %>
           <.form let={f} for={@attack_set} id="attack-form" phx_submit="attack_shields" phx_change="validate_attack">
 
             <%= number_input(f, :amount,
@@ -472,10 +432,10 @@
               width="12"
               class="inline"
             />
-            <span><%= @city.shields %>/<%= @city.shields_capacity %></span>
+            <span><%= @city_stats |> MayorGame.City.TownStatistics.getResource(:shields) |> MayorGame.City.ResourceStatistics.expressStockOverStorage_SI() %></span>
           </div>
         <% else %>
-          <%= if @city.shields <= 0 do %>
+          <%= if @city_stats |> MayorGame.City.TownStatistics.getResource(:shields) |> MayorGame.City.ResourceStatistics.getStock() <= 0 do %>
             <button
               disabled
               class="opacity-50 btn m-0 rounded-none border border-neutral-800/25 leading-none h-6"
@@ -497,7 +457,7 @@
                 class="inline"
               /> Attack city shields |
             </button>
-            <%= @city.shields %>
+            <%= @city_stats |> MayorGame.City.TownStatistics.getResource(:shields) |> MayorGame.City.ResourceStatistics.expressStock_SI() %>
           <% end %>
         <% end %>
       </div>
@@ -523,7 +483,7 @@
                 </h3>
                 <div class="tooltip w-48">
                   <%= for {building_stat, value} <- building_stats do %>
-                    <%= if !String.contains?(Atom.to_string(building_stat), ["multipliers", "price", "purchasable", "produces", "requires", "enabled", "priority", "reason", "title", "category", "level"]) && value != nil do %>
+                    <%= if !String.contains?(Atom.to_string(building_stat), ["multipliers", "price", "purchasable", "produces", "requires", "stores", "enabled", "priority", "reason", "title", "category", "level"]) && value != nil do %>
                       <div class="flex items-center gap-1">
                         <div class=""><%= building_stat %></div>
                         <hr class="border-neutral-800 flex-1" />
@@ -536,7 +496,7 @@
                     <%= for {requires_type, value} <- building_stats.requires do %>
                       <%= if is_number(value) do %>
                         <div class="flex items-center gap-1">
-                          <div class=""><%= to_string(requires_type) %></div>
+                          <div class=""><%= String.replace(to_string(requires_type), "_", " ") %></div>
                           <hr class="border-neutral-800 flex-1" />
                           <%= to_string(value) %>
                         </div>
@@ -544,7 +504,7 @@
                         <%= if requires_type == :workers do %>
                           <div class="flex items-center gap-1">
                             <div class="">
-                              lvl <%= to_string(value.level) <> " " <> to_string(requires_type) %>
+                              lvl <%= to_string(value.level) <> " " <> String.replace(to_string(requires_type), "_", " ") %>
                             </div>
                             <hr class="border-neutral-800 flex-1" />
                             <%= to_string(value.count) %>
@@ -558,7 +518,7 @@
                     <%= for {produces_type, value} <- building_stats.produces do %>
                       <%= if is_number(value) do %>
                         <div class="flex items-center gap-1">
-                          <div class=""><%= to_string(produces_type) %></div>
+                          <div class=""><%= String.replace(to_string(produces_type), "_", " ") %></div>
                           <hr class="border-neutral-800 flex-1" />
                           <%= to_string(round(value)) %>
                           <%= if value != building_stats.actual_produces[produces_type] do %>
@@ -571,9 +531,8 @@
                         </div>
                       <% else %>
                         <%= if is_function(value, 1) && produces_type == :pollution do %>
-
                             <div class="flex items-center gap-1">
-                              <div class=""><%= to_string(produces_type) %> per pop</div>
+                              <div class=""><%= String.replace(to_string(produces_type), "_", " ") %> per pop</div>
                               <hr class="border-neutral-800 flex-1" />
                               <%= value.(1) %>
                               <%= if value.(1) != building_stats.actual_produces[produces_type].(1) do %>
@@ -588,27 +547,34 @@
                               <% end %>
                             </div>
                         <% else %>
-                          <div class="flex items-center gap-1">
-                            <div class=""><%= to_string(produces_type) %></div>
-                            <hr class="border-neutral-800 flex-1" />
-                            random drop
-                          </div>
-                        <% end %>
-                        <%= if is_function(value, 2) do %>
-                          <div class="flex items-center gap-1">
-                            <div class=""><%= to_string(produces_type) %></div>
-                            <hr class="border-neutral-800 flex-1" />
-                            random drop
-                          </div>
+                          <%= if is_function(value, 2) do %>
+                            <div class="flex items-center gap-1">
+                              <div class=""><%= String.replace(to_string(produces_type), "_", " ") %></div>
+                              <hr class="border-neutral-800 flex-1" />
+                              random drop
+                            </div>
+                          <% end %>
                         <% end %>
                         <%= if is_map(value) do %>
                             <div class="flex items-center gap-1">
-                            <div class=""><%= to_string(produces_type) %></div>
+                            <div class=""><%= String.replace(to_string(produces_type), "_", " ") %></div>
                             <hr class="border-neutral-800 flex-1" />
-                            <%= to_string(hd(Map.keys(value))) %> / 
+                            <%= to_string(hd(Map.keys(value))) %> /
                             <%= to_string(hd(Map.values(value))) %>
                           </div>
                         <% end %>
+                      <% end %>
+                    <% end %>
+                  <% end %>
+                  <%= if building_stats.stores != nil do %>
+                    <span class="font-semibold">Stores:</span>
+                    <%= for {stores_type, value} <- building_stats.stores do %>
+                      <%= if is_number(value) do %>
+                        <div class="flex items-center gap-1">
+                          <div class=""><%= String.replace(to_string(stores_type), "_", " ") %></div>
+                          <hr class="border-neutral-800 flex-1" />
+                          <%= to_string(round(value)) %>
+                        </div>
                       <% end %>
                     <% end %>
                   <% end %>
@@ -617,7 +583,7 @@
               <!-- build & delete buttons -->
               <div class="flex flex-row ">
                 <%= if @is_user_mayor do %>
-                  <%= if @city.treasury > building_stats.price do %>
+                  <%= if @city_stats |> MayorGame.City.TownStatistics.getResource(:money) |> MayorGame.City.ResourceStatistics.getStock(-@construction_cost) > building_stats.price do %>
                     <button
                       class="btn m-0 rounded-none border border-neutral-800/25 leading-none h-6"
                       phx-click="purchase_building"
@@ -645,7 +611,7 @@
                       <div class="tooltip w-28">not enough money</div>
                     </div>
                   <% end %>
-                  <%= if length(Map.get(@city, building_type)) > 0 do %>
+                  <%= if (@city_stats |> MayorGame.City.TownStatistics.getBuildable(building_type)).number + (if !is_nil(@construction_count[building_type]) do @construction_count[building_type] else 0 end) > 0 do %>
                     <button
                       phx-click="demolish_building"
                       class="btn m-0 rounded-none border border-l-0 border-neutral-800/25 leading-none h-6"
@@ -663,7 +629,7 @@
                     </button>
                   <% end %>
                   <div class="relative group pl-2 flex items-center">
-                      
+
                       <img
                         src="/images/priority.svg"
                         alt="priority sort"
@@ -672,7 +638,7 @@
                       />
                     <div class="tooltip w-32">Sort the order that you want your buildings to activate. Lower numbers fill first.</div>
                   </div>
-                  <input  
+                  <input
                 class="btn ml-1 text-sm bg-amber-50 p-[2px] border leading-none w-10 border-neutral-800/25"
                 step="1"
                 phx-blur="update_priorities"
@@ -684,8 +650,8 @@
               />
                 <% end %>
                 <%= if @current_user && !is_nil(@current_user.town) && !@is_user_mayor do %>
-                  <%= if !Enum.empty?(Map.get(@operating_count, building_type)) && @current_user.town.missiles > 0 do %>
-                    <%= if @city.shields == 0 do %>
+                  <%= if Map.get(@operating_count, building_type, 0) != 0 && @current_user.town.missiles > 0 do %>
+                    <%= if @city_stats |> MayorGame.City.TownStatistics.getResource(:shields) |> MayorGame.City.ResourceStatistics.getStock() == 0 do %>
                       <div class="relative group">
                         <button
                           phx-click="attack_building"
@@ -746,71 +712,99 @@
               <table border="1" class=" table-fixed border-collapse">
                 <tr>
                   <!-- if no buildings -->
-                  <%= if Enum.empty?(@operating_count[building_type]) do %>
+                  <%= if (@city_stats |> MayorGame.City.TownStatistics.getBuildable(building_type)).number == 0 && (if !is_nil(@construction_count[building_type]) do @construction_count[building_type] else 0 end) == 0 do %>
                     <td class="cell text-neutral-800/50">0</td>
                   <% else %>
-                    <%= for {operation_type, operation_count} <- @operating_count[building_type] do %>
+                    <%= if (@city_stats |> MayorGame.City.TownStatistics.getBuildable(building_type)).operational > 0 do %>
+                      <td class="group cell bg-green-100">
+                        <div class="flex flex-row items-center gap-x-1 cursor-help">
+                          <p class="text-green-700">
+                            <%= Number.Delimit.number_to_delimited((@city_stats |> MayorGame.City.TownStatistics.getBuildable(building_type)).operational) %>
+                          </p>
+                          <%= for requirement <- @building_requirements do %>
+                            <%= if building_stats.requires[String.to_existing_atom(requirement)] != nil && building_stats.requires[String.to_existing_atom(requirement)] > 0 do %>
+                              <img
+                                src={"/images/#{to_string(requirement)}-fulfilled.svg"}
+                                alt={"has enough #{to_string(requirement)} to operate"}
+                                height="12"
+                                width="12"
+                              />
+                            <% end %>
+                          <% end %>
+                          <div class="tooltip text-green-600">operational</div>
+                        </div>
+                      </td>
+                    <% end %>
+                    <%= if !is_nil((@city_stats |> MayorGame.City.TownStatistics.getBuildable(building_type)).deficient_prereq_next) && length((@city_stats |> MayorGame.City.TownStatistics.getBuildable(building_type)).deficient_prereq_next) > 0 do %>
                       <td class={
-                        "group cell #{if operation_type == [] || operation_type == [:loading], do: 'bg-green-100', else: 'bg-red-50'}"
+                        "group cell bg-red-50"
                       }>
                         <div class="flex flex-row items-center gap-x-1 cursor-help">
-                          <p class={
-                            "#{if operation_type == [] || operation_type == [:loading], do: 'text-green-700', else: 'text-red-700'}"
-                          }>
-                            <%= Number.Delimit.number_to_delimited(operation_count) %>
+                          <p class="text-red-700">
+                            <%= Number.Delimit.number_to_delimited((@city_stats |> MayorGame.City.TownStatistics.getBuildable(building_type)).number - (@city_stats |> MayorGame.City.TownStatistics.getBuildable(building_type)).operational) %>
                           </p>
-                          <%= if operation_type == [:loading] do %>
-                          <span class="text-green-600">building…</span>
-                          <% else %>
-                            <%= for requirement <- @building_requirements do %>
-                              <%= if building_stats.requires[String.to_existing_atom(requirement)] != nil && building_stats.requires[String.to_existing_atom(requirement)] > 0 && !Enum.member?(operation_type, String.to_existing_atom(requirement)) do %>
+                          <%= for requirement <- @building_requirements do %>
+                            <%= if building_stats.requires[String.to_existing_atom(requirement)] != nil && building_stats.requires[String.to_existing_atom(requirement)] > 0 && !Enum.member?((@city_stats |> MayorGame.City.TownStatistics.getBuildable(building_type)).deficient_prereq_next, String.to_existing_atom(requirement)) do %>
+                              <img
+                                src={"/images/#{to_string(requirement)}-fulfilled.svg"}
+                                alt={"has enough #{to_string(requirement)} to operate"}
+                                height="12"
+                                width="12"
+                              />
+                            <% else %>
+                              <%= if Enum.member?((@city_stats |> MayorGame.City.TownStatistics.getBuildable(building_type)).deficient_prereq_next, String.to_existing_atom(requirement)) do %>
                                 <img
-                                  src={"/images/#{to_string(requirement)}-fulfilled.svg"}
-                                  alt={"has enough #{to_string(requirement)} to operate"}
+                                  src={"/images/#{to_string(requirement)}-off.svg"}
+                                  alt={"requires #{to_string(requirement)} to operate"}
                                   height="12"
                                   width="12"
                                 />
-                              <% else %>
-                                <%= if Enum.member?(operation_type, String.to_existing_atom(requirement)) do %>
-                                  <img
-                                    src={"/images/#{to_string(requirement)}-off.svg"}
-                                    alt={"requires #{to_string(requirement)} to operate"}
-                                    height="12"
-                                    width="12"
-                                  />
-                                <% end %>
                               <% end %>
                             <% end %>
                           <% end %>
 
-                          <%= if operation_type == [] do %>
-                            <div class="tooltip text-green-600">operational</div>
-                          <% else %>
-                            <%= if operation_type == [:loading] do %>
-                                  <div class="tooltip text-neutral-800">building…</div>
+                          <div class="tooltip w-32 text-red-600">
+                            needs
+                            <%= if length((@city_stats |> MayorGame.City.TownStatistics.getBuildable(building_type)).deficient_prereq_next) > 1 do %>
+                              <%= for operation_reason <- (@city_stats |> MayorGame.City.TownStatistics.getBuildable(building_type)).deficient_prereq_next do %>
+                                <%= operation_reason %>,
+                              <% end %>
                             <% else %>
-                              <div class="tooltip w-32 text-red-600">
-                                needs
-                                <%= if length(operation_type) > 1 do %>
-                                  <%= for operation_reason <- operation_type do %>
-                                    <%= operation_reason %>,
-                                  <% end %>
-                                <% else %>
-                                  <%= hd(operation_type) %>
-                                <% end %>
-                                to operate
-                              </div>
+                              <%= hd((@city_stats |> MayorGame.City.TownStatistics.getBuildable(building_type)).deficient_prereq_next) %>
                             <% end %>
-                          <% end %>
+                            to operate
+                          </div>
                         </div>
                       </td>
+                    <% end %>
+                    <%= if !is_nil(@construction_count[building_type]) do %>
+                      <%= if @construction_count[building_type] > 0 do %>
+                        <td class="group cell bg-green-100">
+                          <div class="flex flex-row items-center gap-x-1 cursor-help">
+                            <p class="text-green-700">
+                              <%= Number.Delimit.number_to_delimited(@construction_count[building_type]) %>
+                            </p>
+                            <span class="text-green-600">building…</span>
+                          </div>
+                        </td>
+                      <% end %>
+                      <%= if @construction_count[building_type] < 0 do %>
+                        <td class="group cell bg-red-100">
+                          <div class="flex flex-row items-center gap-x-1 cursor-help">
+                            <p class="text-red-700">
+                              <%= Number.Delimit.number_to_delimited(-@construction_count[building_type]) %>
+                            </p>
+                            <span class="text-red-600">demolishing…</span>
+                          </div>
+                        </td>
+                      <% end %>
                     <% end %>
                   <% end %>
                 </tr>
               </table>
               <!-- for each operating building, multiply by energy, workers_required, area -->
               <div class="flex flex-row flex-wrap gap-[2px] items-center">
-                <%= if Map.has_key?(@operating_count[building_type], []) do %>
+                <%= if !is_nil(Map.get(@city_stats.buildable_stats, building_type)) && Map.get(@city_stats.buildable_stats, building_type).operational > 0 do %>
                   <%= for {subtotal_type, append_class} <- @subtotal_types do %>
                     <!-- produced -->
                     <%= if !is_nil(building_stats.actual_produces) && Map.has_key?(building_stats.actual_produces, subtotal_type) do %>
@@ -826,9 +820,9 @@
                           height="10"
                           width="10"
                         />
-                        <%= if abs(@operating_count[building_type][[]] * building_stats.actual_produces[subtotal_type]) >= 10_000 do %>
+                        <%= if abs(Map.get(@city_stats.buildable_stats, building_type).operational * building_stats.actual_produces[subtotal_type]) >= 10_000 do %>
                           <%= Number.SI.number_to_si(
-                            @operating_count[building_type][[]] *
+                            Map.get(@city_stats.buildable_stats, building_type).operational *
                               building_stats.actual_produces[subtotal_type],
                             precision: 3,
                             trim: true
@@ -836,15 +830,15 @@
                         <% else %>
                           <%= Number.Delimit.number_to_delimited(
                             round(
-                              @operating_count[building_type][[]] *
+                              Map.get(@city_stats.buildable_stats, building_type).operational *
                                 building_stats.actual_produces[subtotal_type]
                             )
                           ) %>
                         <% end %>
                         <div class="tooltip">
-                          <%= if abs(@operating_count[building_type][[]] * building_stats.actual_produces[subtotal_type]) >= 10_000 do %>
+                          <%= if abs(Map.get(@city_stats.buildable_stats, building_type).operational * building_stats.actual_produces[subtotal_type]) >= 10_000 do %>
                             <%= Number.SI.number_to_si(
-                              @operating_count[building_type][[]] *
+                              Map.get(@city_stats.buildable_stats, building_type).operational *
                                 building_stats.actual_produces[subtotal_type],
                               precision: 3,
                               trim: true
@@ -852,7 +846,7 @@
                           <% else %>
                             <%= Number.Delimit.number_to_delimited(
                               round(
-                                @operating_count[building_type][[]] *
+                                Map.get(@city_stats.buildable_stats, building_type).operational *
                                   building_stats.actual_produces[subtotal_type]
                               )
                             ) %> <%= subtotal_type %> generated
@@ -874,9 +868,9 @@
                           height="10"
                           width="10"
                         />
-                        <%= if abs(@operating_count[building_type][[]] * building_stats.requires[subtotal_type]) >= 10_000 do %>
+                        <%= if abs(Map.get(@city_stats.buildable_stats, building_type).operational * building_stats.requires[subtotal_type]) >= 10_000 do %>
                           <%= Number.SI.number_to_si(
-                            -@operating_count[building_type][[]] *
+                            -Map.get(@city_stats.buildable_stats, building_type).operational *
                               building_stats.requires[subtotal_type],
                             precision: 3,
                             trim: true
@@ -884,15 +878,15 @@
                         <% else %>
                           <%= Number.Delimit.number_to_delimited(
                             round(
-                              -@operating_count[building_type][[]] *
+                              -Map.get(@city_stats.buildable_stats, building_type).operational *
                                 building_stats.requires[subtotal_type]
                             )
                           ) %>
                         <% end %>
                         <div class="tooltip">
-                          <%= if abs(@operating_count[building_type][[]] * building_stats.requires[subtotal_type]) >= 10_000 do %>
+                          <%= if abs(Map.get(@city_stats.buildable_stats, building_type).operational * building_stats.requires[subtotal_type]) >= 10_000 do %>
                             <%= Number.SI.number_to_si(
-                              @operating_count[building_type][[]] *
+                              Map.get(@city_stats.buildable_stats, building_type).operational *
                                 building_stats.requires[subtotal_type],
                               precision: 3,
                               trim: true
@@ -900,7 +894,7 @@
                           <% else %>
                             <%= Number.Delimit.number_to_delimited(
                               round(
-                                @operating_count[building_type][[]] *
+                                Map.get(@city_stats.buildable_stats, building_type).operational *
                                   building_stats.requires[subtotal_type]
                               )
                             ) %>
@@ -922,9 +916,7 @@
                       <%= if is_number(building_stats.produces.pollution) do %>
                         <%= Number.SI.number_to_si(
                           round(
-                            @operating_count[
-                              building_type
-                            ][[]] * building_stats.produces.pollution
+                            Map.get(@city_stats.buildable_stats, building_type).operational * building_stats.produces.pollution
                           ),
                           precision: 3,
                           trim: true
@@ -933,9 +925,7 @@
                         <%= if is_function(building_stats.produces.pollution, 1) do %>
                           <%= Number.SI.number_to_si(
                             round(
-                              @operating_count[
-                                building_type
-                              ][[]] * building_stats.produces.pollution.(@total_citizens)
+                              Map.get(@city_stats.buildable_stats, building_type).operational * building_stats.produces.pollution.(@city_stats.total_citizens)
                             ),
                             precision: 3,
                             trim: true
@@ -945,9 +935,7 @@
                       <div class="tooltip">
                         <%= if is_number(building_stats.produces.pollution) do %>
                           <%= Number.Delimit.number_to_delimited(
-                            @operating_count[
-                              building_type
-                            ][[]] * building_stats.produces.pollution
+                            Map.get(@city_stats.buildable_stats, building_type).operational * building_stats.produces.pollution
                           ) %> pollution generated
                         <% else %>
                           <%= if is_function(building_stats.produces.pollution, 1) do %>
@@ -968,7 +956,7 @@
                       />
                       -<%= Number.SI.number_to_si(
                         round(
-                          @operating_count[building_type][[]] * building_stats.requires.money
+                          Map.get(@city_stats.buildable_stats, building_type).operational * building_stats.requires.money
                         ),
                         precision: 3,
                         trim: true
@@ -976,7 +964,7 @@
                       <div class="tooltip max-w-sm">
                         <%= Number.Delimit.number_to_delimited(
                           round(
-                            @operating_count[building_type][[]] * building_stats.requires.money
+                            Map.get(@city_stats.buildable_stats, building_type).operational * building_stats.requires.money
                           )
                         ) %> running expenses
                       </div>
@@ -992,7 +980,7 @@
                       />
                       -<%= Number.SI.number_to_si(
                         round(
-                          @operating_count[building_type][[]] * building_stats.produces.money
+                          Map.get(@city_stats.buildable_stats, building_type).operational * building_stats.produces.money
                         ),
                         precision: 3,
                         trim: true
@@ -1000,7 +988,7 @@
                       <div class="tooltip max-w-sm">
                         <%= Number.Delimit.number_to_delimited(
                           round(
-                            @operating_count[building_type][[]] * building_stats.produces.money
+                            Map.get(@city_stats.buildable_stats, building_type).operational * building_stats.produces.money
                           )
                         ) %> running income
                       </div>
@@ -1015,10 +1003,10 @@
                         height="10"
                         width="10"
                       />
-                      <%= @operating_count[building_type][[]] *
+                      <%= Map.get(@city_stats.buildable_stats, building_type).operational *
                         building_stats.requires.workers.count %>/<%= building_stats.requires.workers.level %>
                       <div class="tooltip max-w-sm">
-                        <%= @operating_count[building_type][[]] *
+                        <%= Map.get(@city_stats.buildable_stats, building_type).operational *
                           building_stats.requires.workers.count %> workers employed at level <%= building_stats.requires.workers.level %>
                       </div>
                     </div>
@@ -1086,7 +1074,7 @@
           </div>
         </div>
         <div>
-          <%= @city.region %>
+          <%= @city_stats.region %>
         </div>
       </div>
       <!-- CLIMATE -->
@@ -1100,7 +1088,7 @@
           </div>
         </div>
         <div>
-          <%= @city.climate %>
+          <%= @city_stats.climate %>
         </div>
       </div>
       <!-- BIRTH LOGS -->

--- a/mix.exs
+++ b/mix.exs
@@ -59,7 +59,8 @@ defmodule MayorGame.MixProject do
       {:faker, "~> 0.17"},
       {:pow_postgres_store, "~> 1.0"},
       {:number, "~> 1.0.3"},
-      {:flow, "~> 1.0"}
+      {:flow, "~> 1.0"},
+      {:statistics, "~> 0.6.2"}
     ]
   end
 


### PR DESCRIPTION
This is going to be a big one. I'll try to cover all the changes, but it is best to run it on a dev/test server and check.

- **Organization**
> Implemented structures to generalize calculated structs and support further changes
>
> -- **`MayorGame.City.TownStatistics`**: The calculated stats, devoid of RNG, to be used for the live view and further calculations
>
> -- **`MayorGame.City.TownMigrationStatistics`**: The calculated stats specifically for the migration process
>
> -- **`MayorGame.City.ResourceStatistics`**: A sub-structure, that contains the logic used by the resources. Inventory, storage, income. consumption, and drop functions are supported by this structure. Helper functions allow additive merge, multiply, and retrieve select quantities in certain string form (SI, delimited)
>
> -- **`MayorGame.City.BuildableStatistics`**: A sub-structure, that contains the states of each buildable type in `TownStatistics`. This replaces the individual buildable list.


- **Refactors**
> Move some common functions to MayorGame.Rules, allowing them to be viewed and changed easily in the future.
![image](https://user-images.githubusercontent.com/22878527/221404097-2d1f9344-9d6f-42e5-9da7-b33b61643ae7.png)

- **Reworks**
> Replaced `calculate_city_stats`. Three functions are now used in city_helper
>
> -- **`calculate_city_stats`**: Common code used by the live view, calculator and migrator. This function is devoid of RNG, performs job filling, production calculations EXCEPT drops and enforces storage limits. The elimination of `:rand` means live view does not have to worry about random values on refresh. Drops are excluded in this function due to their dependence on `:rand`.
>
> -- **`calculate_city_stats_with_drops`**: As above, but with drops calculated. This is used by the calculator and migrator for server-side processing.
>
> -- **`calculate_citizen_stats`**: Calculation of citizen side stats, and sorts a city's citizens to categories. Used by the migrator to determine the citizens that will migrate.


- **Reworks (`calculate_city_stats`)**
> **Purpose**: Generate buildable operation states, production totals and other resource fixes (capacities, workers, housing). The minimum required to be shown on the live view
>
> `fill_worker` function constructs BuildableStatistics to host aggregate values to represent multiple instances of the same building. Instead of individual buildables, the process need only be done once, assuming no revisits (see next paragraph)
> 
> The algorithm resets to the front of the buildable priority list and revisits higher priority buildables when a resource is produced that is demanded by a buildable type that is not completely food (e.g. due to lack of area). _This allows first priority buildings to be fed by resources produced by buildables lower in priority_. A double `Enum.reduce_while` loop is used to perform this.
> ![image](https://user-images.githubusercontent.com/22878527/221405486-105f4bc6-766a-4f51-a6a1-003387821db4.png)


- **Reworks (`calculate_citizen_stats`)**
> **Purpose**: Generate aggregate numeric stats (e.g. deaths, births, promotions), as well as sorting the citizens into each category as required by migrator code.
>
> Instead of iterating over every citizen, the citizens are categorized by a series of list splits. This also reduces the number of `:rand` calls needed, since `:rand` is called on the size of the list instead of per individual. 


- **Reworks (city_live)**
> The city variable is now unmodified. Modifications are kept in separate assigns (construction_count, construction_cost, town_stats). This avoids expensive manipulations of the city struct.


- **Reworks (miscellaneous)**
> Removed `:has_job` from citizen attributes, as the new method has no more need to track jobs. Reduces DB complexity
> 
> Modifications to city_calculator, city_migrator, city_view, and city show template to use the new structures, and convenient call macros such as `TownStatistics.getResource()` and `ResourceStatistics.expressProduction_SI()`.


- **Modifications**
> Changes to buildable metadata in three fronts:
>
> produces -> <resource>_stores are moved to its own stores field
> ![image](https://user-images.githubusercontent.com/22878527/221404948-b2bbd82e-2fef-43a4-a456-71a8d5bf4244.png)
> The view had been updated to show this information
> ![image](https://user-images.githubusercontent.com/22878527/221405021-862b37e7-3dd5-4938-9fe2-68df80030a5c.png)
>
> Random drop functions are now fully contained within buildable definitions, inclusive of the chance and amount to drop. External code need only know that a function/2 and function/3 are random drop functions.
> ![image](https://user-images.githubusercontent.com/22878527/221405857-4f139d35-6b9b-4a4a-9fdf-12f80db23eb0.png)
>
> Low-luck rolls (i.e. summing the chances and rolling only for the fractional amount) is used to reduce the number of `:rand` calls to a bare minimum.
>
> Instead of maintaining produces -> education as a map, education buildings provide a new set of resources to indicate what level the education is for (e.g. education_lvl_3). This name is also rendered with spaces on live view. The original :education resource is reserved for the library, and this resource is split into the other 5 levels of resources by random weight.
> ![image](https://user-images.githubusercontent.com/22878527/221406079-e59ed561-e13b-4251-b720-7ca25b21ad7b.png)
> ![image](https://user-images.githubusercontent.com/22878527/221406112-33c56cfa-723c-4f2a-90b1-eded079e6ca2.png)
>
> Added a counterpart to the pending building message, for demolition.
> ![image](https://user-images.githubusercontent.com/22878527/221406950-5026df37-f7f6-437b-9a6f-8a9638db974c.png)
>
> Modified post-tick messages to include some timestamps and tick duration. This can be used for basic profiling
> ![image](https://user-images.githubusercontent.com/22878527/221407226-fe001b9b-edf3-475c-9238-d16610c792dc.png)


**Fixes**
> Fix game crash when making invalid construction or demolition of buildings between refresh ticks. This is fixed by correcting the return value of `MayorGame.City.purchase_buildable` and 'MayorGame.City.demolish_buildable`
>
> Was theoretically possible to generate money by demolishing below 0. The refund money is given, regardless or not the buildable can actually be removed. Implemented the same guards as purchase_buildable to ensure the demolition is successful before refunding the money.
>
> Ghost cities are still possible (e.g. ACME Corp on the global dashboard). You can even exploit the ghost check, by building only roads and parks. This added check will help ensure these cities can be processed until they are truly shut down.
> ![image](https://user-images.githubusercontent.com/22878527/221407139-ed941bfc-e47e-4ba1-93e5-ffd236d9cbfc.png)


Whew. Take your time. Feel free to review and comment on specific parts in case you want to implement it separately.

Note these changes are largely catered for the rewrite of city_helpers. city_calculator, city_migrator and city_live will be the next targets of optimization to go.