### PR TITLE
Proposed education batch size changes

### DIFF
--- a/lib/mayor_game/city/buildable.ex
+++ b/lib/mayor_game/city/buildable.ex
@@ -924,7 +924,7 @@ defmodule MayorGame.City.Buildable do
           workers: %{count: 10, level: 0}
         },
         produces: %{
-          education_lvl_1: 10
+          education_lvl_1: 50
         }
       },
       # MIDDLE SCHOOLS ————————————————————————————————————
@@ -941,7 +941,7 @@ defmodule MayorGame.City.Buildable do
           workers: %{count: 10, level: 1}
         },
         produces: %{
-          education_lvl_2: 10
+          education_lvl_2: 30
         }
       },
       # HIGH SCHOOLS ————————————————————————————————————
@@ -958,7 +958,7 @@ defmodule MayorGame.City.Buildable do
           workers: %{count: 10, level: 2}
         },
         produces: %{
-          education_lvl_3: 10
+          education_lvl_3: 20
         }
       },
       # UNIVERSITIES ————————————————————————————————————
@@ -992,7 +992,7 @@ defmodule MayorGame.City.Buildable do
           workers: %{count: 10, level: 4}
         },
         produces: %{
-          education_lvl_5: 10
+          education_lvl_5: 5
         }
       },
       # Resources ——————————————————————————————————————


### PR DESCRIPTION
Based on discussion "Education tick rework"
![image](https://user-images.githubusercontent.com/22878527/222915252-ed13d648-34ff-4fde-a4f9-cb74154edc5b.png)

The population sways between a glut of L0s and a glut of L5, with sparse L1 to L4s.
This can be attributed to multiple reasons:
 - The cost creep of buildings are the same, so large cities tend to have equal number of schools of each kind. This means that most L1-L4s tend to promote to the next level without left over. This means L1-L4 don't accumulate
 - Life expectancy increases with education level, This favors L5 accumulation.

Different suggestions had been made, such as (1) decreasing the rates of lower education promotions, (2) reducing the cost of lower education buildables, and (3) increasing the education batch size.

This PR works on (3), as it is the easiest to change and least like to be exploited (e.g. changing costs of buildings). The thread suggested a favorable steady ratio of 100 L1s to 80 L2s to 70 L3s to 40 L4s to 50 L5s. The combination of 50/30/20/10/5 batch sizes for education buildings gives a close result, while keeping to a nice round number of batch sizes.

Note that this has a nerf to research labs, whose batch size is reduced from 10 to 5.

You may wish to counterbalance it with higher worker requirements, if you'd like.
