### PR TITLE
Don't allow players to "give' negative amounts

### DIFF
--- a/lib/mayor_game_web/live/city_live.ex
+++ b/lib/mayor_game_web/live/city_live.ex
@@ -782,7 +782,7 @@ defmodule MayorGameWeb.CityLive do
 
     # update cities
 
-    if !is_nil(resource) && amount < giving_town_struct[resource_key] do
+    if !is_nil(resource) && amount < giving_town_struct[resource_key] && amount > 0 do
       from(t in Town, where: [id: ^current_user.town.id])
       |> Repo.update_all(inc: [{resource_key, neg_amount}])
 


### PR DESCRIPTION
The only check preventing negative trade quantities is currently a clientside `min` attribute on the input tag, and can be sidestepped pretty easily. This allows "stealing" resources from other players, including putting them into negative stockpiles.

This is a 1-liner PR to add a quick check to trade -- checked that it works as-expected locally.
@warronbebster 